### PR TITLE
feat: adiciona runtime Ubuntu Linux x64

### DIFF
--- a/DOC/RUNTIME_UBUNTU_X64.md
+++ b/DOC/RUNTIME_UBUNTU_X64.md
@@ -1,0 +1,143 @@
+# CHATGPT-AI Runtime para Ubuntu Linux x64
+
+## Alvo
+
+Perfil para:
+
+- Ubuntu x86_64;
+- Debian x86_64;
+- distribuições compatíveis com `apt-get`.
+
+## Dependências de sistema
+
+O script instala:
+
+```bash
+sudo apt-get install -y \
+  ca-certificates curl unzip zip git build-essential cmake pkg-config \
+  python3 python3-venv python3-pip python3-dev \
+  libopenblas-dev libopenblas0 libssl-dev libsndfile1 \
+  ffmpeg poppler-utils
+```
+
+## Runtime produzido
+
+O bundle contém:
+
+```text
+bin/
+  llama-server
+  llama-cli
+  whisper-cli
+  python3
+  pdftotext
+
+python/
+  bootstrap.sh
+  requirements-linux-x64.txt
+
+models/
+scripts/
+  validate_runtime.sh
+BUILD_INFO.txt
+```
+
+O ambiente Python é criado na máquina de destino, em `python/venv`, na primeira execução de `bin/python3`.
+
+## Construção
+
+```bash
+chmod +x runtime/linux-x64/*.sh
+./runtime/linux-x64/install_prerequisites.sh
+./runtime/linux-x64/build_runtime.sh
+./runtime/linux-x64/package_runtime.sh
+```
+
+Resultado:
+
+```text
+.runtime-dist/CHATGPT-AI-runtime-linux-x64.zip
+.runtime-dist/SHA256SUMS-linux-x64.txt
+```
+
+## Release
+
+O ZIP deve ser publicado no GitHub Release com o nome:
+
+```text
+CHATGPT-AI-runtime-linux-x64.zip
+```
+
+O hash deve ser incorporado ao arquivo comum:
+
+```text
+SHA256SUMS.txt
+```
+
+O `runtime/runtime_manifest.ini` já aponta `linux-x64` para `releases/latest/download`.
+
+## Instalação
+
+```bash
+./runtime/linux-x64/install_runtime.sh
+```
+
+O instalador:
+
+1. valida que a máquina é Linux x64;
+2. baixa o ZIP da Release;
+3. baixa `SHA256SUMS.txt`;
+4. confere SHA256;
+5. faz backup do `chatgpt_ai_runtime.ini` anterior;
+6. extrai o runtime;
+7. corrige permissões;
+8. gera novo `chatgpt_ai_runtime.ini`;
+9. executa a validação.
+
+## Caminho padrão
+
+```text
+~/.local/share/chatgpt-ai
+```
+
+Para instalação compartilhada:
+
+```bash
+CHATGPT_AI_HOME=/opt/chatgpt-ai ./runtime/linux-x64/install_runtime.sh
+```
+
+## Arquivo de configuração
+
+```ini
+[runtime]
+platform=linux-x64
+root=/home/user/.local/share/chatgpt-ai
+
+[tools]
+python=/home/user/.local/share/chatgpt-ai/bin/python3
+llama_server=/home/user/.local/share/chatgpt-ai/bin/llama-server
+whisper=/home/user/.local/share/chatgpt-ai/bin/whisper-cli
+pdftotext=/home/user/.local/share/chatgpt-ai/bin/pdftotext
+ffmpeg=/usr/bin/ffmpeg
+```
+
+## Instalador gráfico Lazarus
+
+O projeto `runtime/installer/runtime_installer.lpi` possui o modo:
+
+```text
+LinuxX64
+```
+
+Compilação automática:
+
+```bash
+cd runtime/installer
+./build_runtime_installer.sh
+```
+
+Saída:
+
+```text
+RuntimeInstaller_linux_x64
+```

--- a/installer/linux-x64/install.sh
+++ b/installer/linux-x64/install.sh
@@ -1,4 +1,13 @@
-echo CHATGPT-AI Linux x64 installer
-uname -m
+#!/usr/bin/env bash
+set -euo pipefail
 
-echo This release package must copy runtime assets, generate chatgpt_ai_runtime.ini and install Lazarus packages with lazbuild.
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNTIME_INSTALLER="$ROOT_DIR/runtime/linux-x64/install_runtime.sh"
+
+if [[ ! -f "$RUNTIME_INSTALLER" ]]; then
+  echo "ERRO: runtime/linux-x64/install_runtime.sh não encontrado." >&2
+  exit 2
+fi
+
+chmod +x "$RUNTIME_INSTALLER"
+exec "$RUNTIME_INSTALLER" "$@"

--- a/runtime/build_linux_x64_release.sh
+++ b/runtime/build_linux_x64_release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "ERRO: Linux obrigatório." >&2
+  exit 2
+fi
+case "$(uname -m)" in
+  x86_64|amd64) ;;
+  *) echo "ERRO: esperado x86_64; detectado $(uname -m)." >&2; exit 3 ;;
+esac
+
+chmod +x "$ROOT_DIR/runtime/linux-x64/"*.sh
+"$ROOT_DIR/runtime/linux-x64/build_runtime.sh"
+"$ROOT_DIR/runtime/linux-x64/package_runtime.sh"
+
+DIST_DIR="${DIST_DIR:-$ROOT_DIR/.runtime-dist}"
+HASH_FILE="$DIST_DIR/SHA256SUMS-linux-x64.txt"
+COMMON_FILE="$DIST_DIR/SHA256SUMS.txt"
+
+if [[ -f "$HASH_FILE" ]]; then
+  touch "$COMMON_FILE"
+  grep -v 'CHATGPT-AI-runtime-linux-x64.zip' "$COMMON_FILE" > "$COMMON_FILE.tmp" || true
+  cat "$HASH_FILE" >> "$COMMON_FILE.tmp"
+  mv "$COMMON_FILE.tmp" "$COMMON_FILE"
+fi
+
+echo
+echo "Ubuntu/Linux x64 release pronto:"
+echo "  $DIST_DIR/CHATGPT-AI-runtime-linux-x64.zip"
+echo "  $COMMON_FILE"

--- a/runtime/installer/build_runtime_installer.sh
+++ b/runtime/installer/build_runtime_installer.sh
@@ -12,8 +12,8 @@ if [[ -z "$MODE" ]]; then
   case "$(uname -m)" in
     aarch64|arm64) MODE="LinuxARM64" ;;
     armv7l|armv7*|armhf) MODE="LinuxARMHF" ;;
-    x86_64|amd64) MODE="Release64" ;;
-    i386|i486|i586|i686) MODE="Release32" ;;
+    x86_64|amd64) MODE="LinuxX64" ;;
+    i386|i486|i586|i686) echo "Linux x86 32 bits ainda não possui build mode." >&2; exit 2 ;;
     *) echo "Arquitetura não suportada automaticamente: $(uname -m)" >&2; exit 2 ;;
   esac
 fi

--- a/runtime/installer/runtime_installer.lpi
+++ b/runtime/installer/runtime_installer.lpi
@@ -9,19 +9,22 @@
       <UseAppBundle Value="False"/>
       <ResourceType Value="res"/>
     </General>
-    <BuildModes Count="4" Active="Release64">
+    <BuildModes Count="5" Active="Release64">
       <Item1 Name="Release64">
         <CompilerOptions><Version Value="11"/><Target><Filename Value="RuntimeInstaller_64"/></Target><SearchPaths><UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/></SearchPaths><CodeGeneration><TargetCPU Value="x86_64"/><TargetOS Value="win64"/><Optimizations><OptimizationLevel Value="3"/></Optimizations></CodeGeneration><Linking><Options><Win32><GraphicApplication Value="True"/></Win32></Options></Linking></CompilerOptions>
       </Item1>
       <Item2 Name="Release32">
         <CompilerOptions><Version Value="11"/><Target><Filename Value="RuntimeInstaller_32"/></Target><SearchPaths><UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/></SearchPaths><CodeGeneration><TargetCPU Value="i386"/><TargetOS Value="win32"/><Optimizations><OptimizationLevel Value="3"/></Optimizations></CodeGeneration><Linking><Options><Win32><GraphicApplication Value="True"/></Win32></Options></Linking></CompilerOptions>
       </Item2>
-      <Item3 Name="LinuxARM64">
-        <CompilerOptions><Version Value="11"/><Target><Filename Value="RuntimeInstaller_arm64"/></Target><SearchPaths><UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/></SearchPaths><CodeGeneration><TargetCPU Value="aarch64"/><TargetOS Value="linux"/><Optimizations><OptimizationLevel Value="3"/></Optimizations></CodeGeneration></CompilerOptions>
+      <Item3 Name="LinuxX64">
+        <CompilerOptions><Version Value="11"/><Target><Filename Value="RuntimeInstaller_linux_x64"/></Target><SearchPaths><UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/></SearchPaths><CodeGeneration><TargetCPU Value="x86_64"/><TargetOS Value="linux"/><Optimizations><OptimizationLevel Value="3"/></Optimizations></CodeGeneration></CompilerOptions>
       </Item3>
-      <Item4 Name="LinuxARMHF">
-        <CompilerOptions><Version Value="11"/><Target><Filename Value="RuntimeInstaller_armhf"/></Target><SearchPaths><UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/></SearchPaths><CodeGeneration><TargetCPU Value="arm"/><TargetOS Value="linux"/><Optimizations><OptimizationLevel Value="2"/></Optimizations></CodeGeneration></CompilerOptions>
+      <Item4 Name="LinuxARM64">
+        <CompilerOptions><Version Value="11"/><Target><Filename Value="RuntimeInstaller_arm64"/></Target><SearchPaths><UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/></SearchPaths><CodeGeneration><TargetCPU Value="aarch64"/><TargetOS Value="linux"/><Optimizations><OptimizationLevel Value="3"/></Optimizations></CodeGeneration></CompilerOptions>
       </Item4>
+      <Item5 Name="LinuxARMHF">
+        <CompilerOptions><Version Value="11"/><Target><Filename Value="RuntimeInstaller_armhf"/></Target><SearchPaths><UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/></SearchPaths><CodeGeneration><TargetCPU Value="arm"/><TargetOS Value="linux"/><Optimizations><OptimizationLevel Value="2"/></Optimizations></CodeGeneration></CompilerOptions>
+      </Item5>
     </BuildModes>
     <Units Count="3">
       <Unit0><Filename Value="runtime_installer.lpr"/><IsPartOfProject Value="True"/></Unit0>

--- a/runtime/linux-x64/README.md
+++ b/runtime/linux-x64/README.md
@@ -1,0 +1,74 @@
+# Ubuntu / Linux x64 Runtime
+
+Perfil principal para Ubuntu/Debian em `x86_64`.
+
+## Preparar a máquina
+
+```bash
+chmod +x runtime/linux-x64/*.sh
+./runtime/linux-x64/install_prerequisites.sh
+```
+
+## Montar o runtime
+
+```bash
+./runtime/linux-x64/build_runtime.sh
+./runtime/linux-x64/package_runtime.sh
+```
+
+Resultado:
+
+```text
+.runtime-dist/CHATGPT-AI-runtime-linux-x64.zip
+.runtime-dist/SHA256SUMS-linux-x64.txt
+```
+
+## Instalar pela Release
+
+```bash
+./runtime/linux-x64/install_runtime.sh
+```
+
+Por padrão instala em:
+
+```text
+~/.local/share/chatgpt-ai
+```
+
+Para instalar em outro local:
+
+```bash
+CHATGPT_AI_HOME=/opt/chatgpt-ai ./runtime/linux-x64/install_runtime.sh
+```
+
+## Conteúdo do perfil
+
+- `llama-server` e `llama-cli` quando gerado;
+- `whisper-cli`;
+- bootstrap Python local;
+- NumPy;
+- OpenCV headless;
+- wrapper `pdftotext` usando `poppler-utils` do sistema;
+- FFmpeg do sistema;
+- validação do runtime.
+
+## Validação
+
+```bash
+./runtime/linux-x64/validate_runtime.sh
+```
+
+## Instalador gráfico
+
+Em uma máquina Ubuntu x64 com Lazarus instalado:
+
+```bash
+cd runtime/installer
+./build_runtime_installer.sh
+```
+
+O script detecta `x86_64` e usa o modo `LinuxX64`, gerando:
+
+```text
+RuntimeInstaller_linux_x64
+```

--- a/runtime/linux-x64/build_runtime.sh
+++ b/runtime/linux-x64/build_runtime.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK_DIR="${WORK_DIR:-$ROOT_DIR/.runtime-build/linux-x64}"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/.runtime-out/linux-x64}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 2)}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "ERRO: este script deve rodar em Linux." >&2; exit 2
+fi
+case "$(uname -m)" in
+  x86_64|amd64) ;;
+  *) echo "ERRO: esperado x86_64; detectado $(uname -m)." >&2; exit 3 ;;
+esac
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "ERRO: comando ausente: $1" >&2; exit 4; }; }
+for c in git cmake "$PYTHON_BIN" curl unzip zip sha256sum; do need "$c"; done
+
+mkdir -p "$WORK_DIR" "$OUT_DIR/bin" "$OUT_DIR/models" "$OUT_DIR/python" "$OUT_DIR/scripts"
+
+clone_or_update() {
+  local url="$1" dir="$2"
+  if [[ -d "$dir/.git" ]]; then
+    git -C "$dir" fetch --depth=1 origin
+    git -C "$dir" reset --hard origin/HEAD
+  else
+    git clone --depth=1 "$url" "$dir"
+  fi
+}
+
+echo "== llama.cpp Linux x64 =="
+clone_or_update https://github.com/ggml-org/llama.cpp "$WORK_DIR/llama.cpp"
+cmake -S "$WORK_DIR/llama.cpp" -B "$WORK_DIR/llama.cpp/build" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS \
+  -DGGML_NATIVE=ON
+cmake --build "$WORK_DIR/llama.cpp/build" --config Release -j "$JOBS"
+cp -f "$WORK_DIR/llama.cpp/build/bin/llama-server" "$OUT_DIR/bin/"
+[[ -f "$WORK_DIR/llama.cpp/build/bin/llama-cli" ]] && cp -f "$WORK_DIR/llama.cpp/build/bin/llama-cli" "$OUT_DIR/bin/"
+
+echo "== whisper.cpp Linux x64 =="
+clone_or_update https://github.com/ggml-org/whisper.cpp "$WORK_DIR/whisper.cpp"
+cmake -S "$WORK_DIR/whisper.cpp" -B "$WORK_DIR/whisper.cpp/build" \
+  -DCMAKE_BUILD_TYPE=Release -DGGML_BLAS=ON
+cmake --build "$WORK_DIR/whisper.cpp/build" --config Release -j "$JOBS"
+cp -f "$WORK_DIR/whisper.cpp/build/bin/whisper-cli" "$OUT_DIR/bin/"
+
+cat > "$OUT_DIR/python/requirements-linux-x64.txt" <<'EOF'
+numpy
+opencv-python-headless
+EOF
+
+cat > "$OUT_DIR/python/bootstrap.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV="$ROOT/python/venv"
+if [[ ! -x "$VENV/bin/python" ]]; then
+  python3 -m venv "$VENV"
+  "$VENV/bin/python" -m pip install --upgrade pip setuptools wheel
+  "$VENV/bin/python" -m pip install -r "$ROOT/python/requirements-linux-x64.txt"
+fi
+exec "$VENV/bin/python" "$@"
+EOF
+chmod +x "$OUT_DIR/python/bootstrap.sh"
+
+cat > "$OUT_DIR/bin/python3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$ROOT/python/bootstrap.sh" "$@"
+EOF
+chmod +x "$OUT_DIR/bin/python3"
+
+cat > "$OUT_DIR/bin/pdftotext" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+EXE="$(command -v /usr/bin/pdftotext 2>/dev/null || command -v pdftotext 2>/dev/null || true)"
+if [[ -z "$EXE" || "$EXE" == "$0" ]]; then
+  echo "pdftotext não encontrado. Instale poppler-utils." >&2
+  exit 127
+fi
+exec "$EXE" "$@"
+EOF
+chmod +x "$OUT_DIR/bin/pdftotext"
+
+cat > "$OUT_DIR/BUILD_INFO.txt" <<EOF
+platform=linux-x64
+machine=$(uname -m)
+kernel=$(uname -r)
+python=$($PYTHON_BIN --version 2>&1)
+llama_source=https://github.com/ggml-org/llama.cpp
+whisper_source=https://github.com/ggml-org/whisper.cpp
+built_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+
+echo "Runtime Ubuntu/Linux x64 montado em: $OUT_DIR"

--- a/runtime/linux-x64/install_prerequisites.sh
+++ b/runtime/linux-x64/install_prerequisites.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "ERRO: Linux obrigatório." >&2
+  exit 2
+fi
+case "$(uname -m)" in
+  x86_64|amd64) ;;
+  *) echo "ERRO: esperado Linux x64; detectado $(uname -m)." >&2; exit 3 ;;
+esac
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "ERRO: este script foi preparado para Ubuntu/Debian com apt-get." >&2
+  exit 4
+fi
+
+sudo apt-get update
+sudo apt-get install -y \
+  ca-certificates curl unzip zip git build-essential cmake pkg-config \
+  python3 python3-venv python3-pip python3-dev \
+  libopenblas-dev libopenblas0 libssl-dev libsndfile1 \
+  ffmpeg poppler-utils
+
+echo "Pré-requisitos Ubuntu x64 instalados."

--- a/runtime/linux-x64/install_runtime.sh
+++ b/runtime/linux-x64/install_runtime.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="marcelomaurin/CHATGPT"
+ASSET="CHATGPT-AI-runtime-linux-x64.zip"
+BASE_URL="https://github.com/$REPO/releases/latest/download"
+INSTALL_DIR="${CHATGPT_AI_HOME:-$HOME/.local/share/chatgpt-ai}"
+TMP_DIR="${TMPDIR:-/tmp}/chatgpt-ai-linux-x64-$$"
+
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "ERRO: Linux obrigatório." >&2; exit 2
+fi
+case "$(uname -m)" in
+  x86_64|amd64) ;;
+  *) echo "ERRO: este instalador é Linux x64; detectado $(uname -m)." >&2; exit 3 ;;
+esac
+
+for c in curl unzip sha256sum; do
+  command -v "$c" >/dev/null 2>&1 || { echo "ERRO: pré-requisito ausente: $c" >&2; exit 4; }
+done
+
+mkdir -p "$TMP_DIR" "$INSTALL_DIR"
+echo "CHATGPT-AI Runtime Installer - Ubuntu/Linux x64"
+echo "Destino: $INSTALL_DIR"
+
+echo "Baixando $ASSET..."
+curl -fL --retry 3 --connect-timeout 20 "$BASE_URL/$ASSET" -o "$TMP_DIR/$ASSET"
+curl -fL --retry 3 --connect-timeout 20 "$BASE_URL/SHA256SUMS.txt" -o "$TMP_DIR/SHA256SUMS.txt"
+
+EXPECTED="$(awk -v f="$ASSET" '$2==f || $2=="*"f {print $1; exit}' "$TMP_DIR/SHA256SUMS.txt")"
+if [[ -z "$EXPECTED" ]]; then
+  echo "ERRO: SHA256 de $ASSET não encontrado." >&2; exit 5
+fi
+ACTUAL="$(sha256sum "$TMP_DIR/$ASSET" | awk '{print $1}')"
+if [[ "$EXPECTED" != "$ACTUAL" ]]; then
+  echo "ERRO: SHA256 inválido." >&2; exit 6
+fi
+
+echo "SHA256 OK."
+
+if [[ -f "$INSTALL_DIR/chatgpt_ai_runtime.ini" ]]; then
+  cp -f "$INSTALL_DIR/chatgpt_ai_runtime.ini" "$INSTALL_DIR/chatgpt_ai_runtime.ini.bak"
+fi
+
+unzip -oq "$TMP_DIR/$ASSET" -d "$INSTALL_DIR"
+
+for f in \
+  "$INSTALL_DIR/bin/llama-server" \
+  "$INSTALL_DIR/bin/llama-cli" \
+  "$INSTALL_DIR/bin/whisper-cli" \
+  "$INSTALL_DIR/bin/python3" \
+  "$INSTALL_DIR/bin/pdftotext" \
+  "$INSTALL_DIR/python/bootstrap.sh" \
+  "$INSTALL_DIR/scripts/validate_runtime.sh"; do
+  [[ -f "$f" ]] && chmod +x "$f"
+done
+
+cat > "$INSTALL_DIR/chatgpt_ai_runtime.ini" <<EOF
+[runtime]
+platform=linux-x64
+root=$INSTALL_DIR
+installed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+[tools]
+python=$INSTALL_DIR/bin/python3
+llama_server=$INSTALL_DIR/bin/llama-server
+whisper=$INSTALL_DIR/bin/whisper-cli
+pdftotext=$INSTALL_DIR/bin/pdftotext
+ffmpeg=$(command -v ffmpeg || true)
+EOF
+
+"$INSTALL_DIR/scripts/validate_runtime.sh" "$INSTALL_DIR"
+
+echo
+echo "Runtime Ubuntu/Linux x64 instalado com sucesso em $INSTALL_DIR"

--- a/runtime/linux-x64/package_runtime.sh
+++ b/runtime/linux-x64/package_runtime.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/.runtime-out/linux-x64}"
+DIST_DIR="${DIST_DIR:-$ROOT_DIR/.runtime-dist}"
+ASSET="CHATGPT-AI-runtime-linux-x64.zip"
+
+command -v zip >/dev/null 2>&1 || { echo "ERRO: zip ausente" >&2; exit 2; }
+command -v sha256sum >/dev/null 2>&1 || { echo "ERRO: sha256sum ausente" >&2; exit 2; }
+[[ -x "$OUT_DIR/bin/llama-server" ]] || { echo "ERRO: llama-server ausente" >&2; exit 3; }
+[[ -x "$OUT_DIR/bin/whisper-cli" ]] || { echo "ERRO: whisper-cli ausente" >&2; exit 3; }
+[[ -x "$OUT_DIR/bin/python3" ]] || { echo "ERRO: wrapper python ausente" >&2; exit 3; }
+
+mkdir -p "$OUT_DIR/scripts" "$DIST_DIR"
+cp -f "$ROOT_DIR/runtime/linux-x64/validate_runtime.sh" "$OUT_DIR/scripts/"
+chmod +x "$OUT_DIR/bin/llama-server" "$OUT_DIR/bin/whisper-cli" \
+  "$OUT_DIR/bin/python3" "$OUT_DIR/bin/pdftotext" "$OUT_DIR/scripts/validate_runtime.sh"
+
+rm -f "$DIST_DIR/$ASSET"
+(
+  cd "$OUT_DIR"
+  zip -qr "$DIST_DIR/$ASSET" .
+)
+(
+  cd "$DIST_DIR"
+  sha256sum "$ASSET" > SHA256SUMS-linux-x64.txt
+)
+
+echo "Gerado: $DIST_DIR/$ASSET"
+echo "Hash:   $DIST_DIR/SHA256SUMS-linux-x64.txt"

--- a/runtime/linux-x64/validate_runtime.sh
+++ b/runtime/linux-x64/validate_runtime.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:-${CHATGPT_AI_HOME:-$HOME/.local/share/chatgpt-ai}}"
+FAIL=0
+
+check_exec() {
+  local f="$1" name="$2"
+  if [[ -x "$f" ]]; then echo "[OK] $name: $f"; else echo "[FALTA] $name: $f"; FAIL=1; fi
+}
+
+check_exec "$ROOT/bin/llama-server" "llama-server"
+check_exec "$ROOT/bin/whisper-cli" "whisper-cli"
+check_exec "$ROOT/bin/python3" "python3 wrapper"
+check_exec "$ROOT/bin/pdftotext" "pdftotext wrapper"
+
+if command -v ffmpeg >/dev/null 2>&1; then
+  echo "[OK] ffmpeg: $(command -v ffmpeg)"
+else
+  echo "[FALTA] ffmpeg"
+  FAIL=1
+fi
+
+if [[ -x "$ROOT/bin/python3" ]]; then
+  if "$ROOT/bin/python3" - <<'PY'
+import sys
+print(sys.version)
+import numpy
+import cv2
+print('numpy', numpy.__version__)
+print('opencv', cv2.__version__)
+PY
+  then
+    echo "[OK] Python/NumPy/OpenCV"
+  else
+    echo "[FALTA] Python/NumPy/OpenCV"
+    FAIL=1
+  fi
+fi
+
+if [[ -f "$ROOT/chatgpt_ai_runtime.ini" ]]; then
+  echo "[OK] chatgpt_ai_runtime.ini"
+else
+  echo "[FALTA] chatgpt_ai_runtime.ini"
+  FAIL=1
+fi
+
+exit "$FAIL"


### PR DESCRIPTION
## O que mudou

Adiciona suporte completo ao runtime CHATGPT-AI em Ubuntu/Linux x64.

### Inclui
- instalação de pré-requisitos via apt;
- build nativo de llama.cpp com OpenBLAS;
- build nativo de whisper.cpp;
- bootstrap Python local com venv;
- NumPy e OpenCV headless;
- wrapper para pdftotext/poppler;
- uso de FFmpeg do sistema;
- geração de bundle `CHATGPT-AI-runtime-linux-x64.zip`;
- geração de SHA256;
- instalador shell que baixa da GitHub Release e valida o hash;
- validação pós-instalação;
- documentação Ubuntu x64;
- modo `LinuxX64` no Runtime Installer gráfico;
- correção do build automático: x86_64 Linux agora usa `LinuxX64` em vez do modo Windows `Release64`;
- substituição do antigo `installer/linux-x64/install.sh` esqueleto por um launcher funcional.

## Saída do release

`runtime/build_linux_x64_release.sh` gera o ZIP e atualiza `SHA256SUMS.txt`.

## Observação

O bundle deve ser construído/testado em uma máquina Ubuntu x64 real antes de publicar o asset de Release.