### PR TITLE
ci: recompila samples no Ubuntu Linux x64

### DIFF
--- a/.github/workflows/samples-linux-x64.yml
+++ b/.github/workflows/samples-linux-x64.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build-samples:
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,13 +23,48 @@ jobs:
       - name: Install Lazarus and build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y lazarus fpc fp-utils build-essential file xvfb zip unzip
+          sudo apt-get install -y lazarus fpc fp-utils build-essential file xvfb zip unzip git libgl1-mesa-dev libglu1-mesa-dev libx11-dev
           lazbuild --version
           fpc -iV
           fpc -iTP
           fpc -iTO
 
-      - name: Attempt to register project packages
+      - name: Register Lazarus bundled dependencies
+        run: |
+          set -e
+          IPRO="$(find /usr/lib/lazarus -type f \( -iname 'turbopoweripro.lpk' -o -iname '*ipro*.lpk' \) | head -1 || true)"
+          if [[ -n "$IPRO" ]]; then
+            echo "TurboPowerIpro: $IPRO"
+            lazbuild --add-package "$IPRO"
+          else
+            echo "ERRO: TurboPowerIpro não encontrado na instalação Lazarus" >&2
+            exit 1
+          fi
+
+      - name: Install ZeosLib
+        run: |
+          set -e
+          git clone --depth=1 https://github.com/frones/ZeosLib.git "$RUNNER_TEMP/ZeosLib"
+          Z="$RUNNER_TEMP/ZeosLib/packages/lazarus"
+          for P in zcore zparsesql zplain zdbc zcomponent; do
+            [[ -f "$Z/$P.lpk" ]] && lazbuild --add-package "$Z/$P.lpk"
+          done
+          lazbuild "$Z/zcomponent.lpk"
+
+      - name: Install GLScene/LZScene
+        run: |
+          set -e
+          git clone --depth=1 https://github.com/glscene/LZScene.git "$RUNNER_TEMP/LZScene"
+          lazbuild --add-package "$RUNNER_TEMP/LZScene/Packages/GLScene_RunTime.lpk"
+          lazbuild --add-package "$RUNNER_TEMP/LZScene/Packages/GLScene_DesignTime.lpk"
+
+      - name: Install CEF4Delphi Lazarus package
+        run: |
+          set -e
+          git clone --depth=1 https://github.com/salvadordf/CEF4Delphi.git "$RUNNER_TEMP/CEF4Delphi"
+          lazbuild --add-package "$RUNNER_TEMP/CEF4Delphi/packages/cef4delphi_lazarus.lpk"
+
+      - name: Register CHATGPT packages
         continue-on-error: true
         run: |
           chmod +x ./install_components.sh

--- a/.github/workflows/samples-linux-x64.yml
+++ b/.github/workflows/samples-linux-x64.yml
@@ -7,6 +7,12 @@ on:
       - 'pacote/**'
       - 'tools/ci/compile_samples_linux_x64.sh'
       - '.github/workflows/samples-linux-x64.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'pacote/**'
+      - 'tools/ci/compile_samples_linux_x64.sh'
+      - '.github/workflows/samples-linux-x64.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/samples-linux-x64.yml
+++ b/.github/workflows/samples-linux-x64.yml
@@ -1,0 +1,63 @@
+name: Samples Linux x64
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'pacote/**'
+      - 'tools/ci/compile_samples_linux_x64.sh'
+      - '.github/workflows/samples-linux-x64.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-samples:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Lazarus and build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lazarus fpc fp-utils build-essential file xvfb zip unzip
+          lazbuild --version
+          fpc -iV
+          fpc -iTP
+          fpc -iTO
+
+      - name: Attempt to register project packages
+        continue-on-error: true
+        run: |
+          chmod +x ./install_components.sh
+          ./install_components.sh recommended /usr/bin/lazbuild
+
+      - name: Compile all samples for x86_64-linux
+        id: compile
+        continue-on-error: true
+        run: |
+          chmod +x tools/ci/compile_samples_linux_x64.sh
+          tools/ci/compile_samples_linux_x64.sh
+
+      - name: Upload Linux x64 sample binaries and logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: CHATGPT-samples-linux-x64
+          path: .sample-build/linux-x64/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish report in job summary
+        if: always()
+        run: |
+          if [[ -f .sample-build/linux-x64/REPORT.md ]]; then
+            cat .sample-build/linux-x64/REPORT.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Fail when samples failed
+        if: steps.compile.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/samples-linux-x64.yml
+++ b/.github/workflows/samples-linux-x64.yml
@@ -46,16 +46,21 @@ jobs:
           set -e
           git clone --depth=1 https://github.com/frones/ZeosLib.git "$RUNNER_TEMP/ZeosLib"
           Z="$RUNNER_TEMP/ZeosLib/packages/lazarus"
-          for P in zcore zparsesql zplain zdbc zcomponent; do
-            [[ -f "$Z/$P.lpk" ]] && lazbuild --add-package "$Z/$P.lpk"
+          for P in zcore zparsesql zplain zdbc; do
+            if [[ -f "$Z/$P.lpk" ]]; then
+              echo "Linking Zeos runtime package: $P"
+              lazbuild --add-package-link "$Z/$P.lpk"
+            fi
           done
-          lazbuild "$Z/zcomponent.lpk"
+          lazbuild --add-package "$Z/zcomponent.lpk"
+          lazbuild --build-all "$Z/zcomponent.lpk"
 
       - name: Install GLScene/LZScene
         run: |
           set -e
           git clone --depth=1 https://github.com/glscene/LZScene.git "$RUNNER_TEMP/LZScene"
-          lazbuild --add-package "$RUNNER_TEMP/LZScene/Packages/GLScene_RunTime.lpk"
+          lazbuild --add-package-link "$RUNNER_TEMP/LZScene/Packages/GLScene_RunTime.lpk"
+          lazbuild --build-all "$RUNNER_TEMP/LZScene/Packages/GLScene_RunTime.lpk"
           lazbuild --add-package "$RUNNER_TEMP/LZScene/Packages/GLScene_DesignTime.lpk"
 
       - name: Install CEF4Delphi Lazarus package

--- a/tools/ci/compile_samples_linux_x64.sh
+++ b/tools/ci/compile_samples_linux_x64.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SAMPLES_DIR="$ROOT_DIR/pacote/samples"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/.sample-build/linux-x64}"
+REPORT="$OUT_DIR/REPORT.md"
+LOG_DIR="$OUT_DIR/logs"
+BIN_DIR="$OUT_DIR/bin"
+
+mkdir -p "$LOG_DIR" "$BIN_DIR"
+
+LAZBUILD="${LAZBUILD:-$(command -v lazbuild || true)}"
+if [[ -z "$LAZBUILD" ]]; then
+  echo "ERRO: lazbuild não encontrado" >&2
+  exit 2
+fi
+
+mapfile -d '' PROJECTS < <(find "$SAMPLES_DIR" -type f -name '*.lpi' -print0 | sort -z)
+
+TOTAL=${#PROJECTS[@]}
+OK=0
+FAIL=0
+
+{
+  echo "# Samples Linux x64"
+  echo
+  echo "- Plataforma: x86_64-linux"
+  echo "- lazbuild: $($LAZBUILD --version 2>&1 | head -1)"
+  echo "- Total de projetos: $TOTAL"
+  echo
+  echo "| Sample | Resultado |"
+  echo "|---|---|"
+} > "$REPORT"
+
+for LPI in "${PROJECTS[@]}"; do
+  REL="${LPI#$ROOT_DIR/}"
+  SAFE="$(printf '%s' "$REL" | tr '/ ' '__' | tr -cd '[:alnum:]_.-')"
+  LOG="$LOG_DIR/$SAFE.log"
+  SAMPLE_DIR="$(dirname "$LPI")"
+
+  echo "============================================================"
+  echo "Compilando: $REL"
+  echo "============================================================"
+
+  BEFORE="$OUT_DIR/.before"
+  AFTER="$OUT_DIR/.after"
+  find "$SAMPLE_DIR" -maxdepth 2 -type f -executable -printf '%p\n' 2>/dev/null | sort > "$BEFORE" || true
+
+  if "$LAZBUILD" --build-all --cpu=x86_64 --os=linux "$LPI" >"$LOG" 2>&1; then
+    OK=$((OK+1))
+    echo "| \`$REL\` | OK |" >> "$REPORT"
+
+    find "$SAMPLE_DIR" -maxdepth 2 -type f -executable -printf '%p\n' 2>/dev/null | sort > "$AFTER" || true
+    while IFS= read -r EXE; do
+      [[ -f "$EXE" ]] || continue
+      if file "$EXE" 2>/dev/null | grep -q 'ELF 64-bit'; then
+        NAME="$(basename "$EXE")"
+        DEST_NAME="${NAME%.*}_64${NAME##$NAME*.}"
+        # Linux normalmente não tem extensão; mantém nome limpo com _64.
+        if [[ "$NAME" != *_64 ]]; then DEST_NAME="${NAME}_64"; else DEST_NAME="$NAME"; fi
+        RELDIR="$(dirname "${EXE#$SAMPLES_DIR/}")"
+        mkdir -p "$BIN_DIR/$RELDIR"
+        cp -f "$EXE" "$BIN_DIR/$RELDIR/$DEST_NAME"
+      fi
+    done < "$AFTER"
+  else
+    FAIL=$((FAIL+1))
+    echo "| \`$REL\` | FALHOU |" >> "$REPORT"
+    tail -40 "$LOG" || true
+  fi
+done
+
+{
+  echo
+  echo "## Resumo"
+  echo
+  echo "- Sucesso: $OK"
+  echo "- Falha: $FAIL"
+  echo "- Total: $TOTAL"
+} >> "$REPORT"
+
+echo
+cat "$REPORT"
+
+# Retorna erro quando algum sample falha, mas deixa relatório e logs disponíveis.
+if [[ $FAIL -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Objetivo

Recompilar todos os projetos `.lpi` de `pacote/samples` em Ubuntu/Linux x64.

## Mudanças

- adiciona `tools/ci/compile_samples_linux_x64.sh`;
- força `x86_64-linux` no `lazbuild`;
- gera `REPORT.md` e logs individuais;
- coleta executáveis ELF 64-bit com sufixo `_64` no artifact;
- adiciona GitHub Action Ubuntu 24.04;
- instala Lazarus/FPC no runner;
- tenta registrar os packages do projeto antes dos samples;
- publica artifact `CHATGPT-samples-linux-x64`.

O workflow falha se qualquer sample não compilar, preservando logs para correção.