### PR TITLE
feat: Lazarus AI routing, A2A and development agents

### DIFF
--- a/.github/workflows/package-baseline.yml
+++ b/.github/workflows/package-baseline.yml
@@ -50,7 +50,7 @@ jobs:
           & $lazbuildPath --add-package-link=zeosdbo/packages/lazarus/zcomponent.lpk
           & $lazbuildPath --add-package-link=cef4delphi/packages/cef4delphi_lazarus.lpk
 
-      - name: Compile every tracked package
+      - name: Compile tracked Lazarus packages
         id: baseline
         shell: pwsh
         run: |
@@ -64,13 +64,12 @@ jobs:
           if ($lazbuildCmd) {
             $lazbuildPath = $lazbuildCmd.Source
           } elseif ($env:RUNNER_OS -eq 'Windows') {
-            $candidate = Get-ChildItem -Path 'C:\lazarus*' -Filter lazbuild.exe -File -Recurse -ErrorAction SilentlyContinue |
-              Select-Object -First 1
+            $candidate = Get-ChildItem -Path 'C:\lazarus*' -Filter lazbuild.exe -File -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
             if ($candidate) { $lazbuildPath = $candidate.FullName }
           }
           if (-not $lazbuildPath) { throw 'lazbuild was not found after installing Lazarus.' }
 
-          # C7.4: Ordem topológica de dependências do grafo
+          # Dependency order for the Lazarus/Free Pascal package graph.
           $orderedPackages = @(
             'openai_core.lpk',
             'openai_aidbase.lpk',
@@ -87,7 +86,12 @@ jobs:
             'openai_voice.lpk',
             'openai_agent.lpk',
             'openai_project.lpk',
-            'openai_graph.lpk'
+            'openai_graph.lpk',
+            'openai_rag.lpk',
+            'openai_mcp.lpk',
+            'openai_a2a.lpk',
+            'openai_evaluation.lpk',
+            'openai_observability.lpk'
           )
 
           $rows = [System.Collections.Generic.List[string]]::new()
@@ -107,7 +111,7 @@ jobs:
           }
 
           $rows | Set-Content -LiteralPath (Join-Path $resultDir "$env:RUNNER_OS.tsv") -Encoding utf8
-          if ($rows.Count -ne 16) { throw "Expected 16 packages, measured $($rows.Count)." }
+          if ($rows.Count -ne 21) { throw "Expected 21 packages, measured $($rows.Count)." }
 
       - name: Upload raw baseline
         if: always()
@@ -117,7 +121,7 @@ jobs:
           path: baseline-results/
 
   consolidate:
-    name: Consolidate 16 x 2 baseline
+    name: Consolidate 21 x 2 baseline
     if: always()
     needs: measure
     runs-on: ubuntu-latest
@@ -152,10 +156,10 @@ jobs:
             $out.Add("| ``$($row.Package)`` | $($row.OS) | $($row.Status) | $message |")
           }
           $out.Add('')
-          $out.Add("Measured results: $($rows.Count) (expected: 32).")
+          $out.Add("Measured results: $($rows.Count) (expected: 42).")
           New-Item -ItemType Directory -Force -Path DOC | Out-Null
           $out | Set-Content -LiteralPath 'DOC/FGX_STABILIZATION_BASELINE.md' -Encoding utf8
-          if ($rows.Count -ne 32) { throw "Expected 32 results, consolidated $($rows.Count)." }
+          if ($rows.Count -ne 42) { throw "Expected 42 results, consolidated $($rows.Count)." }
 
       - name: Publish consolidated baseline
         if: always()

--- a/install_components.bat
+++ b/install_components.bat
@@ -1,6 +1,12 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
 
+rem ============================================================
+rem TCHATGPT - Lazarus package installer for Windows
+rem Author: Marcelo Maurin Martins
+rem Repository: https://github.com/marcelomaurin/CHATGPT
+rem ============================================================
+
 set "ROOT_DIR=%~dp0"
 set "LAZBUILD="
 set "MODE=recommended"
@@ -8,6 +14,7 @@ set "FAILED=0"
 
 if not "%~1"=="" set "MODE=%~1"
 if not "%~2"=="" set "LAZBUILD=%~2"
+
 if /I "%MODE%"=="/h" goto :help
 if /I "%MODE%"=="-h" goto :help
 if /I "%MODE%"=="--help" goto :help
@@ -15,37 +22,56 @@ if /I "%MODE%"=="help" goto :help
 
 call :find_lazbuild
 if not exist "%LAZBUILD%" (
+  echo.
   echo [ERROR] lazbuild.exe was not found.
-  goto :help_error
+  echo.
+  echo Usage examples:
+  echo   install_components.bat
+  echo   install_components.bat core
+  echo   install_components.bat all
+  echo   install_components.bat recommended "C:\lazarus\lazbuild.exe"
+  echo.
+  exit /b 1
 )
 
-echo TCHATGPT - Lazarus/Free Pascal installer
-echo Repository: %ROOT_DIR%
-echo lazbuild:   %LAZBUILD%
-echo Mode:       %MODE%
+echo.
+echo ============================================================
+echo TCHATGPT - Component installer for Lazarus / Windows
+echo ============================================================
+echo Repository path: %ROOT_DIR%
+echo lazbuild:       %LAZBUILD%
+echo Mode:           %MODE%
+echo ============================================================
+echo.
 
+echo Building AI Project icons...
 if exist "C:\lazarus\tools\lazres.exe" (
   "C:\lazarus\tools\lazres.exe" "%ROOT_DIR%pacote\AI Project\aiproject_icon.lrs" "%ROOT_DIR%pacote\AI Project\TAIProject.png" "%ROOT_DIR%pacote\AI Project\TAIProjectLLMConfig.png" "%ROOT_DIR%pacote\AI Project\TAIProjectStorage.png"
 )
+echo.
 
 if /I "%MODE%"=="core" (
   call :install_package "pacote\packages\openai_core.lpk"
   goto :finish
 )
+
 if /I "%MODE%"=="recommended" (
   call :install_recommended
   goto :finish
 )
+
 if /I "%MODE%"=="all" (
   call :install_all
   goto :finish
 )
 
 echo [ERROR] Invalid mode: %MODE%
-goto :help_error
+echo.
+goto :help
 
 :find_lazbuild
 if not "%LAZBUILD%"=="" goto :eof
+
 where lazbuild.exe >nul 2>nul
 if %ERRORLEVEL% EQU 0 (
   for /f "delims=" %%I in ('where lazbuild.exe') do (
@@ -53,6 +79,7 @@ if %ERRORLEVEL% EQU 0 (
     goto :eof
   )
 )
+
 if exist "C:\lazarus\lazbuild.exe" set "LAZBUILD=C:\lazarus\lazbuild.exe" & goto :eof
 if exist "C:\Lazarus\lazbuild.exe" set "LAZBUILD=C:\Lazarus\lazbuild.exe" & goto :eof
 if exist "C:\Program Files\Lazarus\lazbuild.exe" set "LAZBUILD=C:\Program Files\Lazarus\lazbuild.exe" & goto :eof
@@ -82,8 +109,26 @@ call :install_package "pacote\packages\openai_files.lpk"
 goto :eof
 
 :install_all
-call :install_recommended
+call :install_package "pacote\packages\openai_core.lpk"
+call :install_package "pacote\packages\openai_ml.lpk"
+call :install_package "pacote\packages\openai_output.lpk"
+call :install_package "pacote\packages\openai_input.lpk"
+call :install_package "pacote\packages\openai_python.lpk"
+call :install_package "pacote\packages\openai_vision.lpk"
+call :install_package "pacote\packages\openai_image.lpk"
+call :install_package "pacote\packages\openai_voice.lpk"
+call :install_package "pacote\packages\openai_industrial.lpk"
+call :install_package "pacote\packages\openai_graphic.lpk"
 call :install_package "pacote\packages\openai_agents.lpk"
+call :install_package "pacote\packages\openai_agent.lpk"
+call :install_package "pacote\packages\openai_graph.lpk"
+call :install_package "pacote\packages\openai_rag.lpk"
+call :install_package "pacote\packages\openai_mcp.lpk"
+call :install_package "pacote\packages\openai_a2a.lpk"
+call :install_package "pacote\packages\openai_evaluation.lpk"
+call :install_package "pacote\packages\openai_observability.lpk"
+call :install_package "pacote\packages\openai_simulation.lpk"
+call :install_package "pacote\packages\openai_files.lpk"
 call :install_package "pacote\packages\openai_aidbase.lpk"
 call :install_package "pacote\packages\openai_dbase.lpk"
 call :install_package "pacote\packages\openai_hardware.lpk"
@@ -93,12 +138,17 @@ goto :eof
 :install_package
 set "PKG_REL=%~1"
 set "PKG=%ROOT_DIR%%PKG_REL%"
+
 if not exist "%PKG%" (
   echo [WARN] Package not found: %PKG_REL%
   set "FAILED=1"
   goto :eof
 )
+
+echo.
+echo ------------------------------------------------------------
 echo Installing package: %PKG_REL%
+echo ------------------------------------------------------------
 "%LAZBUILD%" --add-package "%PKG%"
 if errorlevel 1 (
   echo [ERROR] Failed to install: %PKG_REL%
@@ -109,16 +159,44 @@ if errorlevel 1 (
 goto :eof
 
 :finish
-echo Rebuilding Lazarus IDE...
+echo.
+echo ============================================================
+if "%FAILED%"=="0" (
+  echo Installation commands finished successfully.
+) else (
+  echo Installation finished with warnings or errors.
+  echo Review the messages above before using the components.
+)
+echo.
+echo ------------------------------------------------------------
+echo Rebuilding Lazarus IDE with installed packages...
+echo ------------------------------------------------------------
 "%LAZBUILD%" --build-ide
-if errorlevel 1 set "FAILED=1"
+if errorlevel 1 (
+  echo [ERROR] Lazarus IDE rebuild failed. Open Lazarus and rebuild manually.
+  set "FAILED=1"
+) else (
+  echo [OK] Lazarus IDE rebuilt successfully.
+)
+echo ============================================================
 exit /b %FAILED%
 
 :help
-echo TCHATGPT - Lazarus/Free Pascal Windows installer
-echo Usage: install_components.bat [core^|recommended^|all] [path_to_lazbuild.exe]
+echo.
+echo TCHATGPT - Windows component installer
+echo.
+echo Usage:
+echo   install_components.bat [mode] [path_to_lazbuild.exe]
+echo.
+echo Modes:
+echo   core         Installs only openai_core.lpk
+echo   recommended  Installs the safest base set. Default.
+echo   all          Installs all modular packages.
+echo.
+echo Examples:
+echo   install_components.bat
+echo   install_components.bat core
+echo   install_components.bat all
+echo   install_components.bat recommended "C:\lazarus\lazbuild.exe"
+echo.
 exit /b 0
-
-:help_error
-echo Usage: install_components.bat [core^|recommended^|all] [path_to_lazbuild.exe]
-exit /b 1

--- a/install_components.bat
+++ b/install_components.bat
@@ -1,12 +1,6 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
 
-rem ============================================================
-rem TCHATGPT - Lazarus package installer for Windows
-rem Author: Marcelo Maurin Martins
-rem Repository: https://github.com/marcelomaurin/CHATGPT
-rem ============================================================
-
 set "ROOT_DIR=%~dp0"
 set "LAZBUILD="
 set "MODE=recommended"
@@ -14,7 +8,6 @@ set "FAILED=0"
 
 if not "%~1"=="" set "MODE=%~1"
 if not "%~2"=="" set "LAZBUILD=%~2"
-
 if /I "%MODE%"=="/h" goto :help
 if /I "%MODE%"=="-h" goto :help
 if /I "%MODE%"=="--help" goto :help
@@ -22,56 +15,37 @@ if /I "%MODE%"=="help" goto :help
 
 call :find_lazbuild
 if not exist "%LAZBUILD%" (
-  echo.
   echo [ERROR] lazbuild.exe was not found.
-  echo.
-  echo Usage examples:
-  echo   install_components.bat
-  echo   install_components.bat core
-  echo   install_components.bat all
-  echo   install_components.bat recommended "C:\lazarus\lazbuild.exe"
-  echo.
-  exit /b 1
+  goto :help_error
 )
 
-echo.
-echo ============================================================
-echo TCHATGPT - Component installer for Lazarus / Windows
-echo ============================================================
-echo Repository path: %ROOT_DIR%
-echo lazbuild:       %LAZBUILD%
-echo Mode:           %MODE%
-echo ============================================================
-echo.
+echo TCHATGPT - Lazarus/Free Pascal installer
+echo Repository: %ROOT_DIR%
+echo lazbuild:   %LAZBUILD%
+echo Mode:       %MODE%
 
-echo Building AI Project icons...
 if exist "C:\lazarus\tools\lazres.exe" (
   "C:\lazarus\tools\lazres.exe" "%ROOT_DIR%pacote\AI Project\aiproject_icon.lrs" "%ROOT_DIR%pacote\AI Project\TAIProject.png" "%ROOT_DIR%pacote\AI Project\TAIProjectLLMConfig.png" "%ROOT_DIR%pacote\AI Project\TAIProjectStorage.png"
 )
-echo.
 
 if /I "%MODE%"=="core" (
   call :install_package "pacote\packages\openai_core.lpk"
   goto :finish
 )
-
 if /I "%MODE%"=="recommended" (
   call :install_recommended
   goto :finish
 )
-
 if /I "%MODE%"=="all" (
   call :install_all
   goto :finish
 )
 
 echo [ERROR] Invalid mode: %MODE%
-echo.
-goto :help
+goto :help_error
 
 :find_lazbuild
 if not "%LAZBUILD%"=="" goto :eof
-
 where lazbuild.exe >nul 2>nul
 if %ERRORLEVEL% EQU 0 (
   for /f "delims=" %%I in ('where lazbuild.exe') do (
@@ -79,7 +53,6 @@ if %ERRORLEVEL% EQU 0 (
     goto :eof
   )
 )
-
 if exist "C:\lazarus\lazbuild.exe" set "LAZBUILD=C:\lazarus\lazbuild.exe" & goto :eof
 if exist "C:\Lazarus\lazbuild.exe" set "LAZBUILD=C:\Lazarus\lazbuild.exe" & goto :eof
 if exist "C:\Program Files\Lazarus\lazbuild.exe" set "LAZBUILD=C:\Program Files\Lazarus\lazbuild.exe" & goto :eof
@@ -101,6 +74,7 @@ call :install_package "pacote\packages\openai_agent.lpk"
 call :install_package "pacote\packages\openai_graph.lpk"
 call :install_package "pacote\packages\openai_rag.lpk"
 call :install_package "pacote\packages\openai_mcp.lpk"
+call :install_package "pacote\packages\openai_a2a.lpk"
 call :install_package "pacote\packages\openai_evaluation.lpk"
 call :install_package "pacote\packages\openai_observability.lpk"
 call :install_package "pacote\packages\openai_simulation.lpk"
@@ -108,25 +82,8 @@ call :install_package "pacote\packages\openai_files.lpk"
 goto :eof
 
 :install_all
-call :install_package "pacote\packages\openai_core.lpk"
-call :install_package "pacote\packages\openai_ml.lpk"
-call :install_package "pacote\packages\openai_output.lpk"
-call :install_package "pacote\packages\openai_input.lpk"
-call :install_package "pacote\packages\openai_python.lpk"
-call :install_package "pacote\packages\openai_vision.lpk"
-call :install_package "pacote\packages\openai_image.lpk"
-call :install_package "pacote\packages\openai_voice.lpk"
-call :install_package "pacote\packages\openai_industrial.lpk"
-call :install_package "pacote\packages\openai_graphic.lpk"
+call :install_recommended
 call :install_package "pacote\packages\openai_agents.lpk"
-call :install_package "pacote\packages\openai_agent.lpk"
-call :install_package "pacote\packages\openai_graph.lpk"
-call :install_package "pacote\packages\openai_rag.lpk"
-call :install_package "pacote\packages\openai_mcp.lpk"
-call :install_package "pacote\packages\openai_evaluation.lpk"
-call :install_package "pacote\packages\openai_observability.lpk"
-call :install_package "pacote\packages\openai_simulation.lpk"
-call :install_package "pacote\packages\openai_files.lpk"
 call :install_package "pacote\packages\openai_aidbase.lpk"
 call :install_package "pacote\packages\openai_dbase.lpk"
 call :install_package "pacote\packages\openai_hardware.lpk"
@@ -136,17 +93,12 @@ goto :eof
 :install_package
 set "PKG_REL=%~1"
 set "PKG=%ROOT_DIR%%PKG_REL%"
-
 if not exist "%PKG%" (
   echo [WARN] Package not found: %PKG_REL%
   set "FAILED=1"
   goto :eof
 )
-
-echo.
-echo ------------------------------------------------------------
 echo Installing package: %PKG_REL%
-echo ------------------------------------------------------------
 "%LAZBUILD%" --add-package "%PKG%"
 if errorlevel 1 (
   echo [ERROR] Failed to install: %PKG_REL%
@@ -157,44 +109,16 @@ if errorlevel 1 (
 goto :eof
 
 :finish
-echo.
-echo ============================================================
-if "%FAILED%"=="0" (
-  echo Installation commands finished successfully.
-) else (
-  echo Installation finished with warnings or errors.
-  echo Review the messages above before using the components.
-)
-echo.
-echo ------------------------------------------------------------
-echo Rebuilding Lazarus IDE with installed packages...
-echo ------------------------------------------------------------
+echo Rebuilding Lazarus IDE...
 "%LAZBUILD%" --build-ide
-if errorlevel 1 (
-  echo [ERROR] Lazarus IDE rebuild failed. Open Lazarus and rebuild manually.
-  set "FAILED=1"
-) else (
-  echo [OK] Lazarus IDE rebuilt successfully.
-)
-echo ============================================================
+if errorlevel 1 set "FAILED=1"
 exit /b %FAILED%
 
 :help
-echo.
-echo TCHATGPT - Windows component installer
-echo.
-echo Usage:
-echo   install_components.bat [mode] [path_to_lazbuild.exe]
-echo.
-echo Modes:
-echo   core         Installs only openai_core.lpk
-echo   recommended  Installs the safest base set. Default.
-echo   all          Installs all modular packages.
-echo.
-echo Examples:
-echo   install_components.bat
-echo   install_components.bat core
-echo   install_components.bat all
-echo   install_components.bat recommended "C:\lazarus\lazbuild.exe"
-echo.
+echo TCHATGPT - Lazarus/Free Pascal Windows installer
+echo Usage: install_components.bat [core^|recommended^|all] [path_to_lazbuild.exe]
 exit /b 0
+
+:help_error
+echo Usage: install_components.bat [core^|recommended^|all] [path_to_lazbuild.exe]
+exit /b 1

--- a/install_components.sh
+++ b/install_components.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -u
 
+# ============================================================
+# TCHATGPT - Lazarus package installer for Linux
+# Author: Marcelo Maurin Martins
+# Repository: https://github.com/marcelomaurin/CHATGPT
+# ============================================================
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODE="${1:-recommended}"
 LAZBUILD="${2:-}"
@@ -8,40 +14,68 @@ FAILED=0
 
 show_help() {
   cat <<'EOF'
-TCHATGPT - Lazarus/Free Pascal component installer for Linux
+
+TCHATGPT - Linux component installer
 
 Usage:
   ./install_components.sh [mode] [path_to_lazbuild]
 
 Modes:
   core         Installs only openai_core.lpk
-  recommended  Installs the recommended Lazarus AI packages. Default.
+  recommended  Installs the safest base set. Default.
   all          Installs all modular packages.
+
+Examples:
+  chmod +x install_components.sh
+  ./install_components.sh
+  ./install_components.sh core
+  ./install_components.sh all
+  ./install_components.sh recommended /usr/bin/lazbuild
+
 EOF
 }
 
 find_lazbuild() {
-  if [[ -n "$LAZBUILD" ]]; then return; fi
+  if [[ -n "$LAZBUILD" ]]; then
+    return
+  fi
+
   if command -v lazbuild >/dev/null 2>&1; then
     LAZBUILD="$(command -v lazbuild)"
     return
   fi
-  for candidate in /usr/bin/lazbuild /usr/local/bin/lazbuild /opt/lazarus/lazbuild "$HOME/lazarus/lazbuild"; do
-    if [[ -x "$candidate" ]]; then LAZBUILD="$candidate"; return; fi
+
+  for candidate in \
+    "/usr/bin/lazbuild" \
+    "/usr/local/bin/lazbuild" \
+    "/opt/lazarus/lazbuild" \
+    "$HOME/lazarus/lazbuild"; do
+    if [[ -x "$candidate" ]]; then
+      LAZBUILD="$candidate"
+      return
+    fi
   done
 }
 
 install_package() {
   local pkg_rel="$1"
   local pkg="$ROOT_DIR/$pkg_rel"
+
   if [[ ! -f "$pkg" ]]; then
     echo "[WARN] Package not found: $pkg_rel"
     FAILED=1
     return
   fi
+
+  echo
+  echo "------------------------------------------------------------"
   echo "Installing package: $pkg_rel"
+  echo "------------------------------------------------------------"
+
   "$LAZBUILD" --add-package "$pkg"
-  if [[ $? -ne 0 ]]; then
+  local rc=$?
+
+  if [[ $rc -ne 0 ]]; then
     echo "[ERROR] Failed to install: $pkg_rel"
     FAILED=1
   else
@@ -72,8 +106,26 @@ install_recommended() {
 }
 
 install_all() {
-  install_recommended
+  install_package "pacote/packages/openai_core.lpk"
+  install_package "pacote/packages/openai_ml.lpk"
+  install_package "pacote/packages/openai_output.lpk"
+  install_package "pacote/packages/openai_input.lpk"
+  install_package "pacote/packages/openai_python.lpk"
+  install_package "pacote/packages/openai_vision.lpk"
+  install_package "pacote/packages/openai_image.lpk"
+  install_package "pacote/packages/openai_voice.lpk"
+  install_package "pacote/packages/openai_industrial.lpk"
+  install_package "pacote/packages/openai_graphic.lpk"
   install_package "pacote/packages/openai_agents.lpk"
+  install_package "pacote/packages/openai_agent.lpk"
+  install_package "pacote/packages/openai_graph.lpk"
+  install_package "pacote/packages/openai_rag.lpk"
+  install_package "pacote/packages/openai_mcp.lpk"
+  install_package "pacote/packages/openai_a2a.lpk"
+  install_package "pacote/packages/openai_evaluation.lpk"
+  install_package "pacote/packages/openai_observability.lpk"
+  install_package "pacote/packages/openai_simulation.lpk"
+  install_package "pacote/packages/openai_files.lpk"
   install_package "pacote/packages/openai_aidbase.lpk"
   install_package "pacote/packages/openai_dbase.lpk"
   install_package "pacote/packages/openai_hardware.lpk"
@@ -81,32 +133,84 @@ install_all() {
 }
 
 case "$MODE" in
-  -h|--help|help) show_help; exit 0 ;;
+  -h|--help|help)
+    show_help
+    exit 0
+    ;;
 esac
 
 find_lazbuild
+
 if [[ -z "$LAZBUILD" || ! -x "$LAZBUILD" ]]; then
+  echo
   echo "[ERROR] lazbuild was not found or is not executable."
-  show_help
+  echo
+  echo "Usage examples:"
+  echo "  ./install_components.sh"
+  echo "  ./install_components.sh core"
+  echo "  ./install_components.sh all"
+  echo "  ./install_components.sh recommended /usr/bin/lazbuild"
+  echo
   exit 1
 fi
 
-echo "TCHATGPT - Lazarus/Free Pascal installer"
-echo "Repository: $ROOT_DIR"
-echo "lazbuild:   $LAZBUILD"
-echo "Mode:       $MODE"
+echo
+echo "============================================================"
+echo "TCHATGPT - Component installer for Lazarus / Linux"
+echo "============================================================"
+echo "Repository path: $ROOT_DIR"
+echo "lazbuild:       $LAZBUILD"
+echo "Mode:           $MODE"
+echo "============================================================"
+echo
 
+echo "Building AI Project icons..."
 if command -v lazres >/dev/null 2>&1; then
-  lazres "$ROOT_DIR/pacote/AI Project/aiproject_icon.lrs" "$ROOT_DIR/pacote/AI Project/TAIProject.png" "$ROOT_DIR/pacote/AI Project/TAIProjectLLMConfig.png" "$ROOT_DIR/pacote/AI Project/TAIProjectStorage.png" || true
+  lazres "$ROOT_DIR/pacote/AI Project/aiproject_icon.lrs" "$ROOT_DIR/pacote/AI Project/TAIProject.png" "$ROOT_DIR/pacote/AI Project/TAIProjectLLMConfig.png" "$ROOT_DIR/pacote/AI Project/TAIProjectStorage.png"
+elif [[ -x "/usr/bin/lazres" ]]; then
+  /usr/bin/lazres "$ROOT_DIR/pacote/AI Project/aiproject_icon.lrs" "$ROOT_DIR/pacote/AI Project/TAIProject.png" "$ROOT_DIR/pacote/AI Project/TAIProjectLLMConfig.png" "$ROOT_DIR/pacote/AI Project/TAIProjectStorage.png"
+elif [[ -x "/usr/lib/lazarus/default/tools/lazres" ]]; then
+  /usr/lib/lazarus/default/tools/lazres "$ROOT_DIR/pacote/AI Project/aiproject_icon.lrs" "$ROOT_DIR/pacote/AI Project/TAIProject.png" "$ROOT_DIR/pacote/AI Project/TAIProjectLLMConfig.png" "$ROOT_DIR/pacote/AI Project/TAIProjectStorage.png"
 fi
+echo
 
 case "$MODE" in
-  core) install_package "pacote/packages/openai_core.lpk" ;;
-  recommended) install_recommended ;;
-  all) install_all ;;
-  *) echo "[ERROR] Invalid mode: $MODE"; show_help; exit 1 ;;
+  core)
+    install_package "pacote/packages/openai_core.lpk"
+    ;;
+  recommended)
+    install_recommended
+    ;;
+  all)
+    install_all
+    ;;
+  *)
+    echo "[ERROR] Invalid mode: $MODE"
+    show_help
+    exit 1
+    ;;
 esac
 
-echo "Rebuilding Lazarus IDE..."
-"$LAZBUILD" --build-ide || FAILED=1
+echo
+echo "============================================================"
+if [[ $FAILED -eq 0 ]]; then
+  echo "Installation commands finished successfully."
+else
+  echo "Installation finished with warnings or errors."
+  echo "Review the messages above before using the components."
+fi
+echo
+echo "------------------------------------------------------------"
+echo "Rebuilding Lazarus IDE with installed packages..."
+echo "------------------------------------------------------------"
+"$LAZBUILD" --build-ide
+rc=$?
+if [[ $rc -ne 0 ]]; then
+  echo "[ERROR] Lazarus IDE rebuild failed. Open Lazarus and rebuild manually."
+  FAILED=1
+else
+  echo "[OK] Lazarus IDE rebuilt successfully."
+fi
+echo "============================================================"
+
 exit "$FAILED"

--- a/install_components.sh
+++ b/install_components.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -u
 
-# ============================================================
-# TCHATGPT - Lazarus package installer for Linux
-# Author: Marcelo Maurin Martins
-# Repository: https://github.com/marcelomaurin/CHATGPT
-# ============================================================
-
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODE="${1:-recommended}"
 LAZBUILD="${2:-}"
@@ -14,68 +8,40 @@ FAILED=0
 
 show_help() {
   cat <<'EOF'
-
-TCHATGPT - Linux component installer
+TCHATGPT - Lazarus/Free Pascal component installer for Linux
 
 Usage:
   ./install_components.sh [mode] [path_to_lazbuild]
 
 Modes:
   core         Installs only openai_core.lpk
-  recommended  Installs the safest base set. Default.
+  recommended  Installs the recommended Lazarus AI packages. Default.
   all          Installs all modular packages.
-
-Examples:
-  chmod +x install_components.sh
-  ./install_components.sh
-  ./install_components.sh core
-  ./install_components.sh all
-  ./install_components.sh recommended /usr/bin/lazbuild
-
 EOF
 }
 
 find_lazbuild() {
-  if [[ -n "$LAZBUILD" ]]; then
-    return
-  fi
-
+  if [[ -n "$LAZBUILD" ]]; then return; fi
   if command -v lazbuild >/dev/null 2>&1; then
     LAZBUILD="$(command -v lazbuild)"
     return
   fi
-
-  for candidate in \
-    "/usr/bin/lazbuild" \
-    "/usr/local/bin/lazbuild" \
-    "/opt/lazarus/lazbuild" \
-    "$HOME/lazarus/lazbuild"; do
-    if [[ -x "$candidate" ]]; then
-      LAZBUILD="$candidate"
-      return
-    fi
+  for candidate in /usr/bin/lazbuild /usr/local/bin/lazbuild /opt/lazarus/lazbuild "$HOME/lazarus/lazbuild"; do
+    if [[ -x "$candidate" ]]; then LAZBUILD="$candidate"; return; fi
   done
 }
 
 install_package() {
   local pkg_rel="$1"
   local pkg="$ROOT_DIR/$pkg_rel"
-
   if [[ ! -f "$pkg" ]]; then
     echo "[WARN] Package not found: $pkg_rel"
     FAILED=1
     return
   fi
-
-  echo
-  echo "------------------------------------------------------------"
   echo "Installing package: $pkg_rel"
-  echo "------------------------------------------------------------"
-
   "$LAZBUILD" --add-package "$pkg"
-  local rc=$?
-
-  if [[ $rc -ne 0 ]]; then
+  if [[ $? -ne 0 ]]; then
     echo "[ERROR] Failed to install: $pkg_rel"
     FAILED=1
   else
@@ -98,6 +64,7 @@ install_recommended() {
   install_package "pacote/packages/openai_graph.lpk"
   install_package "pacote/packages/openai_rag.lpk"
   install_package "pacote/packages/openai_mcp.lpk"
+  install_package "pacote/packages/openai_a2a.lpk"
   install_package "pacote/packages/openai_evaluation.lpk"
   install_package "pacote/packages/openai_observability.lpk"
   install_package "pacote/packages/openai_simulation.lpk"
@@ -105,25 +72,8 @@ install_recommended() {
 }
 
 install_all() {
-  install_package "pacote/packages/openai_core.lpk"
-  install_package "pacote/packages/openai_ml.lpk"
-  install_package "pacote/packages/openai_output.lpk"
-  install_package "pacote/packages/openai_input.lpk"
-  install_package "pacote/packages/openai_python.lpk"
-  install_package "pacote/packages/openai_vision.lpk"
-  install_package "pacote/packages/openai_image.lpk"
-  install_package "pacote/packages/openai_voice.lpk"
-  install_package "pacote/packages/openai_industrial.lpk"
-  install_package "pacote/packages/openai_graphic.lpk"
+  install_recommended
   install_package "pacote/packages/openai_agents.lpk"
-  install_package "pacote/packages/openai_agent.lpk"
-  install_package "pacote/packages/openai_graph.lpk"
-  install_package "pacote/packages/openai_rag.lpk"
-  install_package "pacote/packages/openai_mcp.lpk"
-  install_package "pacote/packages/openai_evaluation.lpk"
-  install_package "pacote/packages/openai_observability.lpk"
-  install_package "pacote/packages/openai_simulation.lpk"
-  install_package "pacote/packages/openai_files.lpk"
   install_package "pacote/packages/openai_aidbase.lpk"
   install_package "pacote/packages/openai_dbase.lpk"
   install_package "pacote/packages/openai_hardware.lpk"
@@ -131,84 +81,32 @@ install_all() {
 }
 
 case "$MODE" in
-  -h|--help|help)
-    show_help
-    exit 0
-    ;;
+  -h|--help|help) show_help; exit 0 ;;
 esac
 
 find_lazbuild
-
 if [[ -z "$LAZBUILD" || ! -x "$LAZBUILD" ]]; then
-  echo
   echo "[ERROR] lazbuild was not found or is not executable."
-  echo
-  echo "Usage examples:"
-  echo "  ./install_components.sh"
-  echo "  ./install_components.sh core"
-  echo "  ./install_components.sh all"
-  echo "  ./install_components.sh recommended /usr/bin/lazbuild"
-  echo
+  show_help
   exit 1
 fi
 
-echo
-echo "============================================================"
-echo "TCHATGPT - Component installer for Lazarus / Linux"
-echo "============================================================"
-echo "Repository path: $ROOT_DIR"
-echo "lazbuild:       $LAZBUILD"
-echo "Mode:           $MODE"
-echo "============================================================"
-echo
+echo "TCHATGPT - Lazarus/Free Pascal installer"
+echo "Repository: $ROOT_DIR"
+echo "lazbuild:   $LAZBUILD"
+echo "Mode:       $MODE"
 
-echo "Building AI Project icons..."
 if command -v lazres >/dev/null 2>&1; then
-  lazres "$ROOT_DIR/pacote/AI Project/aiproject_icon.lrs" "$ROOT_DIR/pacote/AI Project/TAIProject.png" "$ROOT_DIR/pacote/AI Project/TAIProjectLLMConfig.png" "$ROOT_DIR/pacote/AI Project/TAIProjectStorage.png"
-elif [[ -x "/usr/bin/lazres" ]]; then
-  /usr/bin/lazres "$ROOT_DIR/pacote/AI Project/aiproject_icon.lrs" "$ROOT_DIR/pacote/AI Project/TAIProject.png" "$ROOT_DIR/pacote/AI Project/TAIProjectLLMConfig.png" "$ROOT_DIR/pacote/AI Project/TAIProjectStorage.png"
-elif [[ -x "/usr/lib/lazarus/default/tools/lazres" ]]; then
-  /usr/lib/lazarus/default/tools/lazres "$ROOT_DIR/pacote/AI Project/aiproject_icon.lrs" "$ROOT_DIR/pacote/AI Project/TAIProject.png" "$ROOT_DIR/pacote/AI Project/TAIProjectLLMConfig.png" "$ROOT_DIR/pacote/AI Project/TAIProjectStorage.png"
+  lazres "$ROOT_DIR/pacote/AI Project/aiproject_icon.lrs" "$ROOT_DIR/pacote/AI Project/TAIProject.png" "$ROOT_DIR/pacote/AI Project/TAIProjectLLMConfig.png" "$ROOT_DIR/pacote/AI Project/TAIProjectStorage.png" || true
 fi
-echo
 
 case "$MODE" in
-  core)
-    install_package "pacote/packages/openai_core.lpk"
-    ;;
-  recommended)
-    install_recommended
-    ;;
-  all)
-    install_all
-    ;;
-  *)
-    echo "[ERROR] Invalid mode: $MODE"
-    show_help
-    exit 1
-    ;;
+  core) install_package "pacote/packages/openai_core.lpk" ;;
+  recommended) install_recommended ;;
+  all) install_all ;;
+  *) echo "[ERROR] Invalid mode: $MODE"; show_help; exit 1 ;;
 esac
 
-echo
-echo "============================================================"
-if [[ $FAILED -eq 0 ]]; then
-  echo "Installation commands finished successfully."
-else
-  echo "Installation finished with warnings or errors."
-  echo "Review the messages above before using the components."
-fi
-echo
-echo "------------------------------------------------------------"
-echo "Rebuilding Lazarus IDE with installed packages..."
-echo "------------------------------------------------------------"
-"$LAZBUILD" --build-ide
-rc=$?
-if [[ $rc -ne 0 ]]; then
-  echo "[ERROR] Lazarus IDE rebuild failed. Open Lazarus and rebuild manually."
-  FAILED=1
-else
-  echo "[OK] Lazarus IDE rebuilt successfully."
-fi
-echo "============================================================"
-
+echo "Rebuilding Lazarus IDE..."
+"$LAZBUILD" --build-ide || FAILED=1
 exit "$FAILED"

--- a/pacote/AI A2A/aia2a.pas
+++ b/pacote/AI A2A/aia2a.pas
@@ -1,0 +1,612 @@
+unit aia2a;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fpjson, jsonparser, fphttpclient, opensslsockets,
+  LResources, aibase;
+
+type
+  TAIA2ABinding = (a2abJSONRPC, a2abHTTPJSON);
+
+  TAIA2AInterface = class
+  public
+    URL: string;
+    ProtocolBinding: string;
+    ProtocolVersion: string;
+    Tenant: string;
+  end;
+
+  TAIA2AAgentCard = class
+  private
+    FName: string;
+    FDescription: string;
+    FVersion: string;
+    FInterfaces: TList;
+    FStreaming: Boolean;
+    FPushNotifications: Boolean;
+    FExtendedAgentCard: Boolean;
+    function GetInterfaceCount: Integer;
+    function GetInterface(AIndex: Integer): TAIA2AInterface;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    procedure Clear;
+    function LoadJSON(const AJSON: string): Boolean;
+    function SelectInterface(ABinding: TAIA2ABinding): TAIA2AInterface;
+    property Name: string read FName;
+    property Description: string read FDescription;
+    property Version: string read FVersion;
+    property Streaming: Boolean read FStreaming;
+    property PushNotifications: Boolean read FPushNotifications;
+    property ExtendedAgentCard: Boolean read FExtendedAgentCard;
+    property InterfaceCount: Integer read GetInterfaceCount;
+    property Interfaces[AIndex: Integer]: TAIA2AInterface read GetInterface;
+  end;
+
+  { TAIA2AClient }
+
+  TAIA2AClient = class(TAIBaseComponent)
+  private
+    FBaseURL: string;
+    FAgentCardURL: string;
+    FToken: string;
+    FProtocolVersion: string;
+    FBinding: TAIA2ABinding;
+    FTimeout: Integer;
+    FAutoDiscover: Boolean;
+    FAgentCard: TAIA2AAgentCard;
+    FLastRawResponse: string;
+    FLastTaskID: string;
+    FLastContextID: string;
+    FSelectedURL: string;
+    FTenant: string;
+    function NormalizeBaseURL(const AURL: string): string;
+    function NewID: string;
+    function DoRequest(const AMethod, AURL: string; ABody: TStream;
+      const AContentType: string; out AResponse: string): Boolean;
+    function DoGet(const AURL: string; out AResponse: string): Boolean;
+    function BuildMessageParams(const AText, ATaskID: string): TJSONObject;
+    function SendJSONRPC(const AMethod: string; AParams: TJSONObject;
+      out AResponse: string): Boolean;
+    function SendHTTPJSON(const APath: string; ABody: TJSONObject;
+      out AResponse: string): Boolean;
+    function ExtractTextAndTask(const ARaw: string; out AText: string): Boolean;
+    procedure SelectDiscoveredInterface;
+  public
+    constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+    function Discover: Boolean;
+    function SendText(const AText: string; out AAnswer: string): Boolean;
+    function ContinueTask(const ATaskID, AText: string;
+      out AAnswer: string): Boolean;
+    function GetTask(const ATaskID: string; out ATaskJSON: string;
+      AHistoryLength: Integer = -1): Boolean;
+    function CancelTask(const ATaskID: string; out ATaskJSON: string): Boolean;
+    property AgentCard: TAIA2AAgentCard read FAgentCard;
+    property LastRawResponse: string read FLastRawResponse;
+    property LastTaskID: string read FLastTaskID;
+    property LastContextID: string read FLastContextID;
+    property SelectedURL: string read FSelectedURL;
+  published
+    property BaseURL: string read FBaseURL write FBaseURL;
+    property AgentCardURL: string read FAgentCardURL write FAgentCardURL;
+    property Token: string read FToken write FToken;
+    property ProtocolVersion: string read FProtocolVersion write FProtocolVersion;
+    property Binding: TAIA2ABinding read FBinding write FBinding default a2abHTTPJSON;
+    property Timeout: Integer read FTimeout write FTimeout default 120000;
+    property AutoDiscover: Boolean read FAutoDiscover write FAutoDiscover default True;
+  end;
+
+procedure Register;
+
+implementation
+
+procedure Register;
+begin
+  RegisterComponents('AI A2A', [TAIA2AClient]);
+end;
+
+function JSONString(AData: TJSONData; const APath: string): string;
+var
+  D: TJSONData;
+begin
+  Result := '';
+  if AData = nil then Exit;
+  D := AData.FindPath(APath);
+  if D <> nil then
+    Result := D.AsString;
+end;
+
+function JSONBool(AData: TJSONData; const APath: string): Boolean;
+var
+  D: TJSONData;
+begin
+  Result := False;
+  if AData = nil then Exit;
+  D := AData.FindPath(APath);
+  if D <> nil then
+    Result := D.AsBoolean;
+end;
+
+{ TAIA2AAgentCard }
+
+constructor TAIA2AAgentCard.Create;
+begin
+  inherited Create;
+  FInterfaces := TList.Create;
+end;
+
+destructor TAIA2AAgentCard.Destroy;
+begin
+  Clear;
+  FInterfaces.Free;
+  inherited Destroy;
+end;
+
+procedure TAIA2AAgentCard.Clear;
+var
+  I: Integer;
+begin
+  for I := FInterfaces.Count - 1 downto 0 do
+    TObject(FInterfaces[I]).Free;
+  FInterfaces.Clear;
+  FName := '';
+  FDescription := '';
+  FVersion := '';
+  FStreaming := False;
+  FPushNotifications := False;
+  FExtendedAgentCard := False;
+end;
+
+function TAIA2AAgentCard.GetInterfaceCount: Integer;
+begin
+  Result := FInterfaces.Count;
+end;
+
+function TAIA2AAgentCard.GetInterface(AIndex: Integer): TAIA2AInterface;
+begin
+  Result := TAIA2AInterface(FInterfaces[AIndex]);
+end;
+
+function TAIA2AAgentCard.LoadJSON(const AJSON: string): Boolean;
+var
+  Root, Item: TJSONData;
+  Arr: TJSONArray;
+  I: Integer;
+  Intf: TAIA2AInterface;
+begin
+  Result := False;
+  Clear;
+  try
+    Root := GetJSON(AJSON);
+    try
+      FName := JSONString(Root, 'name');
+      FDescription := JSONString(Root, 'description');
+      FVersion := JSONString(Root, 'version');
+      FStreaming := JSONBool(Root, 'capabilities.streaming');
+      FPushNotifications := JSONBool(Root, 'capabilities.pushNotifications');
+      FExtendedAgentCard := JSONBool(Root, 'capabilities.extendedAgentCard');
+      Item := Root.FindPath('supportedInterfaces');
+      if (Item <> nil) and (Item.JSONType = jtArray) then
+      begin
+        Arr := TJSONArray(Item);
+        for I := 0 to Arr.Count - 1 do
+        begin
+          Intf := TAIA2AInterface.Create;
+          Intf.URL := JSONString(Arr.Items[I], 'url');
+          Intf.ProtocolBinding := JSONString(Arr.Items[I], 'protocolBinding');
+          Intf.ProtocolVersion := JSONString(Arr.Items[I], 'protocolVersion');
+          Intf.Tenant := JSONString(Arr.Items[I], 'tenant');
+          if Intf.URL <> '' then
+            FInterfaces.Add(Intf)
+          else
+            Intf.Free;
+        end;
+      end;
+      Result := FName <> '';
+    finally
+      Root.Free;
+    end;
+  except
+    Result := False;
+  end;
+end;
+
+function TAIA2AAgentCard.SelectInterface(ABinding: TAIA2ABinding): TAIA2AInterface;
+var
+  I: Integer;
+  S: string;
+begin
+  Result := nil;
+  for I := 0 to FInterfaces.Count - 1 do
+  begin
+    S := UpperCase(Trim(Interfaces[I].ProtocolBinding));
+    case ABinding of
+      a2abJSONRPC:
+        if (S = 'JSONRPC') or (S = 'JSON-RPC') then Exit(Interfaces[I]);
+      a2abHTTPJSON:
+        if (S = 'HTTP+JSON') or (S = 'HTTPJSON') or (S = 'REST') then
+          Exit(Interfaces[I]);
+    end;
+  end;
+end;
+
+{ TAIA2AClient }
+
+constructor TAIA2AClient.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FProtocolVersion := '1.0';
+  FBinding := a2abHTTPJSON;
+  FTimeout := 120000;
+  FAutoDiscover := True;
+  FAgentCard := TAIA2AAgentCard.Create;
+end;
+
+destructor TAIA2AClient.Destroy;
+begin
+  FAgentCard.Free;
+  inherited Destroy;
+end;
+
+function TAIA2AClient.NormalizeBaseURL(const AURL: string): string;
+begin
+  Result := Trim(AURL);
+  while (Result <> '') and (Result[Length(Result)] = '/') do
+    Delete(Result, Length(Result), 1);
+end;
+
+function TAIA2AClient.NewID: string;
+var
+  G: TGUID;
+begin
+  if CreateGUID(G) = 0 then
+    Result := GUIDToString(G)
+  else
+    Result := IntToHex(Random(MaxInt), 8) + IntToHex(Random(MaxInt), 8);
+  Result := StringReplace(Result, '{', '', [rfReplaceAll]);
+  Result := StringReplace(Result, '}', '', [rfReplaceAll]);
+end;
+
+function TAIA2AClient.DoRequest(const AMethod, AURL: string; ABody: TStream;
+  const AContentType: string; out AResponse: string): Boolean;
+var
+  HTTP: TFPHttpClient;
+  ResponseStream: TStringStream;
+begin
+  Result := False;
+  AResponse := '';
+  HTTP := TFPHttpClient.Create(nil);
+  ResponseStream := TStringStream.Create('');
+  try
+    HTTP.ConnectTimeout := FTimeout;
+    HTTP.IOTimeout := FTimeout;
+    HTTP.AddHeader('Accept', AContentType);
+    HTTP.AddHeader('Content-Type', AContentType);
+    HTTP.AddHeader('A2A-Version', FProtocolVersion);
+    if FToken <> '' then
+      HTTP.AddHeader('Authorization', 'Bearer ' + FToken);
+    if FTenant <> '' then
+      HTTP.AddHeader('A2A-Tenant', FTenant);
+    HTTP.RequestBody := ABody;
+    try
+      HTTP.HTTPMethod(AMethod, AURL, ResponseStream, [200, 201, 202]);
+      AResponse := ResponseStream.DataString;
+      FLastRawResponse := AResponse;
+      Result := True;
+    except
+      on E: Exception do
+      begin
+        FLastRawResponse := ResponseStream.DataString;
+        SetError(E.Message + IfThen(FLastRawResponse <> '', ': ' + FLastRawResponse, ''));
+      end;
+    end;
+    HTTP.RequestBody := nil;
+  finally
+    ResponseStream.Free;
+    HTTP.Free;
+  end;
+end;
+
+function TAIA2AClient.DoGet(const AURL: string; out AResponse: string): Boolean;
+var
+  HTTP: TFPHttpClient;
+begin
+  Result := False;
+  AResponse := '';
+  HTTP := TFPHttpClient.Create(nil);
+  try
+    HTTP.ConnectTimeout := FTimeout;
+    HTTP.IOTimeout := FTimeout;
+    HTTP.AddHeader('Accept', 'application/a2a+json, application/json');
+    HTTP.AddHeader('A2A-Version', FProtocolVersion);
+    if FToken <> '' then HTTP.AddHeader('Authorization', 'Bearer ' + FToken);
+    try
+      AResponse := HTTP.Get(AURL);
+      FLastRawResponse := AResponse;
+      Result := True;
+    except
+      on E: Exception do SetError(E.Message);
+    end;
+  finally
+    HTTP.Free;
+  end;
+end;
+
+procedure TAIA2AClient.SelectDiscoveredInterface;
+var
+  Intf: TAIA2AInterface;
+begin
+  Intf := FAgentCard.SelectInterface(FBinding);
+  if Intf = nil then Exit;
+  FSelectedURL := NormalizeBaseURL(Intf.URL);
+  FTenant := Intf.Tenant;
+  if Intf.ProtocolVersion <> '' then
+    FProtocolVersion := Intf.ProtocolVersion;
+end;
+
+function TAIA2AClient.Discover: Boolean;
+var
+  URL, Raw: string;
+begin
+  ClearError;
+  URL := Trim(FAgentCardURL);
+  if URL = '' then
+  begin
+    if FBaseURL = '' then
+    begin
+      SetError('BaseURL ou AgentCardURL deve ser informado.');
+      Exit(False);
+    end;
+    URL := NormalizeBaseURL(FBaseURL) + '/.well-known/agent-card.json';
+  end;
+  Result := DoGet(URL, Raw) and FAgentCard.LoadJSON(Raw);
+  if not Result then
+  begin
+    if FLastError = '' then SetError('Agent Card A2A invalido.');
+    Exit;
+  end;
+  SelectDiscoveredInterface;
+  if FSelectedURL = '' then
+    FSelectedURL := NormalizeBaseURL(FBaseURL);
+  FLastResult := FAgentCard.Name;
+  FLastSuccess := True;
+end;
+
+function TAIA2AClient.BuildMessageParams(const AText, ATaskID: string): TJSONObject;
+var
+  Msg, Part: TJSONObject;
+  Parts: TJSONArray;
+begin
+  Result := TJSONObject.Create;
+  Msg := TJSONObject.Create;
+  Result.Add('message', Msg);
+  Msg.Add('messageId', NewID);
+  Msg.Add('role', 'ROLE_USER');
+  if ATaskID <> '' then Msg.Add('taskId', ATaskID);
+  Parts := TJSONArray.Create;
+  Msg.Add('parts', Parts);
+  Part := TJSONObject.Create;
+  Part.Add('text', AText);
+  Parts.Add(Part);
+  if FTenant <> '' then Result.Add('tenant', FTenant);
+end;
+
+function TAIA2AClient.SendJSONRPC(const AMethod: string; AParams: TJSONObject;
+  out AResponse: string): Boolean;
+var
+  Root: TJSONObject;
+  Body: TStringStream;
+  URL: string;
+begin
+  Root := TJSONObject.Create;
+  try
+    Root.Add('jsonrpc', '2.0');
+    Root.Add('id', NewID);
+    Root.Add('method', AMethod);
+    Root.Add('params', AParams);
+    AParams := nil;
+    Body := TStringStream.Create(Root.AsJSON);
+    try
+      URL := NormalizeBaseURL(FSelectedURL);
+      Result := DoRequest('POST', URL, Body, 'application/json', AResponse);
+    finally
+      Body.Free;
+    end;
+  finally
+    AParams.Free;
+    Root.Free;
+  end;
+end;
+
+function TAIA2AClient.SendHTTPJSON(const APath: string; ABody: TJSONObject;
+  out AResponse: string): Boolean;
+var
+  Body: TStringStream;
+  URL: string;
+begin
+  try
+    Body := TStringStream.Create(ABody.AsJSON);
+    try
+      URL := NormalizeBaseURL(FSelectedURL) + APath;
+      Result := DoRequest('POST', URL, Body, 'application/a2a+json', AResponse);
+    finally
+      Body.Free;
+    end;
+  finally
+    ABody.Free;
+  end;
+end;
+
+function TAIA2AClient.ExtractTextAndTask(const ARaw: string;
+  out AText: string): Boolean;
+var
+  Root, Base, Data, PartsData: TJSONData;
+  Arr: TJSONArray;
+  I, J: Integer;
+  S: string;
+begin
+  Result := False;
+  AText := '';
+  FLastTaskID := '';
+  FLastContextID := '';
+  try
+    Root := GetJSON(ARaw);
+    try
+      Base := Root;
+      Data := Root.FindPath('result');
+      if Data <> nil then Base := Data;
+
+      FLastTaskID := JSONString(Base, 'task.id');
+      FLastContextID := JSONString(Base, 'task.contextId');
+
+      PartsData := Base.FindPath('message.parts');
+      if (PartsData <> nil) and (PartsData.JSONType = jtArray) then
+      begin
+        Arr := TJSONArray(PartsData);
+        for I := 0 to Arr.Count - 1 do
+        begin
+          S := JSONString(Arr.Items[I], 'text');
+          if S <> '' then
+          begin
+            if AText <> '' then AText := AText + LineEnding;
+            AText := AText + S;
+          end;
+        end;
+      end;
+
+      if AText = '' then
+      begin
+        Data := Base.FindPath('task.artifacts');
+        if (Data <> nil) and (Data.JSONType = jtArray) then
+          for I := 0 to TJSONArray(Data).Count - 1 do
+          begin
+            PartsData := TJSONArray(Data).Items[I].FindPath('parts');
+            if (PartsData <> nil) and (PartsData.JSONType = jtArray) then
+              for J := 0 to TJSONArray(PartsData).Count - 1 do
+              begin
+                S := JSONString(TJSONArray(PartsData).Items[J], 'text');
+                if S <> '' then
+                begin
+                  if AText <> '' then AText := AText + LineEnding;
+                  AText := AText + S;
+                end;
+              end;
+          end;
+      end;
+
+      if AText = '' then
+        AText := JSONString(Base, 'task.status.message.parts[0].text');
+
+      Result := (FLastTaskID <> '') or (AText <> '');
+    finally
+      Root.Free;
+    end;
+  except
+    on E: Exception do SetError('Resposta A2A invalida: ' + E.Message);
+  end;
+end;
+
+function TAIA2AClient.SendText(const AText: string; out AAnswer: string): Boolean;
+var
+  Raw: string;
+begin
+  ClearError;
+  if FAutoDiscover and (FAgentCard.InterfaceCount = 0) then
+    if not Discover then Exit(False);
+  if FSelectedURL = '' then FSelectedURL := NormalizeBaseURL(FBaseURL);
+  if FSelectedURL = '' then
+  begin
+    SetError('URL A2A nao configurada.');
+    Exit(False);
+  end;
+
+  if FBinding = a2abJSONRPC then
+    Result := SendJSONRPC('SendMessage', BuildMessageParams(AText, ''), Raw)
+  else
+    Result := SendHTTPJSON('/message:send', BuildMessageParams(AText, ''), Raw);
+
+  if Result then Result := ExtractTextAndTask(Raw, AAnswer);
+  FLastSuccess := Result;
+  if Result then FLastResult := AAnswer;
+end;
+
+function TAIA2AClient.ContinueTask(const ATaskID, AText: string;
+  out AAnswer: string): Boolean;
+var
+  Raw: string;
+begin
+  ClearError;
+  if FSelectedURL = '' then
+    if FAutoDiscover then
+    begin
+      if not Discover then Exit(False);
+    end
+    else
+      FSelectedURL := NormalizeBaseURL(FBaseURL);
+
+  if FBinding = a2abJSONRPC then
+    Result := SendJSONRPC('SendMessage', BuildMessageParams(AText, ATaskID), Raw)
+  else
+    Result := SendHTTPJSON('/message:send', BuildMessageParams(AText, ATaskID), Raw);
+
+  if Result then Result := ExtractTextAndTask(Raw, AAnswer);
+  FLastSuccess := Result;
+  if Result then FLastResult := AAnswer;
+end;
+
+function TAIA2AClient.GetTask(const ATaskID: string; out ATaskJSON: string;
+  AHistoryLength: Integer): Boolean;
+var
+  Params: TJSONObject;
+  URL: string;
+begin
+  ClearError;
+  if FSelectedURL = '' then FSelectedURL := NormalizeBaseURL(FBaseURL);
+  if FBinding = a2abJSONRPC then
+  begin
+    Params := TJSONObject.Create;
+    Params.Add('id', ATaskID);
+    if AHistoryLength >= 0 then Params.Add('historyLength', AHistoryLength);
+    if FTenant <> '' then Params.Add('tenant', FTenant);
+    Result := SendJSONRPC('GetTask', Params, ATaskJSON);
+  end
+  else
+  begin
+    URL := NormalizeBaseURL(FSelectedURL) + '/tasks/' + ATaskID;
+    if AHistoryLength >= 0 then URL := URL + '?historyLength=' + IntToStr(AHistoryLength);
+    Result := DoGet(URL, ATaskJSON);
+  end;
+  FLastSuccess := Result;
+  if Result then FLastResult := ATaskJSON;
+end;
+
+function TAIA2AClient.CancelTask(const ATaskID: string;
+  out ATaskJSON: string): Boolean;
+var
+  Params, EmptyBody: TJSONObject;
+begin
+  ClearError;
+  if FSelectedURL = '' then FSelectedURL := NormalizeBaseURL(FBaseURL);
+  if FBinding = a2abJSONRPC then
+  begin
+    Params := TJSONObject.Create;
+    Params.Add('id', ATaskID);
+    if FTenant <> '' then Params.Add('tenant', FTenant);
+    Result := SendJSONRPC('CancelTask', Params, ATaskJSON);
+  end
+  else
+  begin
+    EmptyBody := TJSONObject.Create;
+    if FTenant <> '' then EmptyBody.Add('tenant', FTenant);
+    Result := SendHTTPJSON('/tasks/' + ATaskID + ':cancel', EmptyBody, ATaskJSON);
+  end;
+  FLastSuccess := Result;
+  if Result then FLastResult := ATaskJSON;
+end;
+
+end.

--- a/pacote/AI A2A/aia2a.pas
+++ b/pacote/AI A2A/aia2a.pas
@@ -5,8 +5,8 @@ unit aia2a;
 interface
 
 uses
-  Classes, SysUtils, fpjson, jsonparser, fphttpclient, opensslsockets,
-  LResources, aibase;
+  Classes, SysUtils, StrUtils, fpjson, jsonparser, fphttpclient,
+  opensslsockets, LResources, aibase;
 
 type
   TAIA2ABinding = (a2abJSONRPC, a2abHTTPJSON);
@@ -45,8 +45,6 @@ type
     property InterfaceCount: Integer read GetInterfaceCount;
     property Interfaces[AIndex: Integer]: TAIA2AInterface read GetInterface;
   end;
-
-  { TAIA2AClient }
 
   TAIA2AClient = class(TAIBaseComponent)
   private
@@ -116,8 +114,7 @@ begin
   Result := '';
   if AData = nil then Exit;
   D := AData.FindPath(APath);
-  if D <> nil then
-    Result := D.AsString;
+  if D <> nil then Result := D.AsString;
 end;
 
 function JSONBool(AData: TJSONData; const APath: string): Boolean;
@@ -127,11 +124,8 @@ begin
   Result := False;
   if AData = nil then Exit;
   D := AData.FindPath(APath);
-  if D <> nil then
-    Result := D.AsBoolean;
+  if D <> nil then Result := D.AsBoolean;
 end;
-
-{ TAIA2AAgentCard }
 
 constructor TAIA2AAgentCard.Create;
 begin
@@ -150,8 +144,7 @@ procedure TAIA2AAgentCard.Clear;
 var
   I: Integer;
 begin
-  for I := FInterfaces.Count - 1 downto 0 do
-    TObject(FInterfaces[I]).Free;
+  for I := FInterfaces.Count - 1 downto 0 do TObject(FInterfaces[I]).Free;
   FInterfaces.Clear;
   FName := '';
   FDescription := '';
@@ -200,10 +193,7 @@ begin
           Intf.ProtocolBinding := JSONString(Arr.Items[I], 'protocolBinding');
           Intf.ProtocolVersion := JSONString(Arr.Items[I], 'protocolVersion');
           Intf.Tenant := JSONString(Arr.Items[I], 'tenant');
-          if Intf.URL <> '' then
-            FInterfaces.Add(Intf)
-          else
-            Intf.Free;
+          if Intf.URL <> '' then FInterfaces.Add(Intf) else Intf.Free;
         end;
       end;
       Result := FName <> '';
@@ -233,8 +223,6 @@ begin
     end;
   end;
 end;
-
-{ TAIA2AClient }
 
 constructor TAIA2AClient.Create(AOwner: TComponent);
 begin
@@ -288,10 +276,7 @@ begin
     HTTP.AddHeader('Accept', AContentType);
     HTTP.AddHeader('Content-Type', AContentType);
     HTTP.AddHeader('A2A-Version', FProtocolVersion);
-    if FToken <> '' then
-      HTTP.AddHeader('Authorization', 'Bearer ' + FToken);
-    if FTenant <> '' then
-      HTTP.AddHeader('A2A-Tenant', FTenant);
+    if FToken <> '' then HTTP.AddHeader('Authorization', 'Bearer ' + FToken);
     HTTP.RequestBody := ABody;
     try
       HTTP.HTTPMethod(AMethod, AURL, ResponseStream, [200, 201, 202]);
@@ -345,8 +330,7 @@ begin
   if Intf = nil then Exit;
   FSelectedURL := NormalizeBaseURL(Intf.URL);
   FTenant := Intf.Tenant;
-  if Intf.ProtocolVersion <> '' then
-    FProtocolVersion := Intf.ProtocolVersion;
+  if Intf.ProtocolVersion <> '' then FProtocolVersion := Intf.ProtocolVersion;
 end;
 
 function TAIA2AClient.Discover: Boolean;
@@ -371,8 +355,7 @@ begin
     Exit;
   end;
   SelectDiscoveredInterface;
-  if FSelectedURL = '' then
-    FSelectedURL := NormalizeBaseURL(FBaseURL);
+  if FSelectedURL = '' then FSelectedURL := NormalizeBaseURL(FBaseURL);
   FLastResult := FAgentCard.Name;
   FLastSuccess := True;
 end;
@@ -460,10 +443,8 @@ begin
       Base := Root;
       Data := Root.FindPath('result');
       if Data <> nil then Base := Data;
-
       FLastTaskID := JSONString(Base, 'task.id');
       FLastContextID := JSONString(Base, 'task.contextId');
-
       PartsData := Base.FindPath('message.parts');
       if (PartsData <> nil) and (PartsData.JSONType = jtArray) then
       begin
@@ -478,7 +459,6 @@ begin
           end;
         end;
       end;
-
       if AText = '' then
       begin
         Data := Base.FindPath('task.artifacts');
@@ -498,10 +478,7 @@ begin
               end;
           end;
       end;
-
-      if AText = '' then
-        AText := JSONString(Base, 'task.status.message.parts[0].text');
-
+      if AText = '' then AText := JSONString(Base, 'task.status.message.parts[0].text');
       Result := (FLastTaskID <> '') or (AText <> '');
     finally
       Root.Free;
@@ -524,12 +501,10 @@ begin
     SetError('URL A2A nao configurada.');
     Exit(False);
   end;
-
   if FBinding = a2abJSONRPC then
     Result := SendJSONRPC('SendMessage', BuildMessageParams(AText, ''), Raw)
   else
     Result := SendHTTPJSON('/message:send', BuildMessageParams(AText, ''), Raw);
-
   if Result then Result := ExtractTextAndTask(Raw, AAnswer);
   FLastSuccess := Result;
   if Result then FLastResult := AAnswer;
@@ -548,12 +523,10 @@ begin
     end
     else
       FSelectedURL := NormalizeBaseURL(FBaseURL);
-
   if FBinding = a2abJSONRPC then
     Result := SendJSONRPC('SendMessage', BuildMessageParams(AText, ATaskID), Raw)
   else
     Result := SendHTTPJSON('/message:send', BuildMessageParams(AText, ATaskID), Raw);
-
   if Result then Result := ExtractTextAndTask(Raw, AAnswer);
   FLastSuccess := Result;
   if Result then FLastResult := AAnswer;

--- a/pacote/AI A2A/aia2aserver.pas
+++ b/pacote/AI A2A/aia2aserver.pas
@@ -1,0 +1,401 @@
+unit aia2aserver;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fpjson, jsonparser, LResources, aibase, aiagent,
+  aiwebserver;
+
+type
+  TAIA2AServer = class(TAIBaseComponent)
+  private
+    FWebServer: TAIWebAPIServer;
+    FAgent: TAIAgent;
+    FPort: Integer;
+    FPublicURL: string;
+    FAgentName: string;
+    FAgentDescription: string;
+    FAgentVersion: string;
+    FProtocolVersion: string;
+    FSkillID: string;
+    FSkillName: string;
+    FActive: Boolean;
+    procedure SetAgent(AValue: TAIAgent);
+    procedure SetActive(AValue: Boolean);
+    procedure HandleRequest(Sender: TObject; const ARoute, AMethod,
+      AContent: string; out AResponse: string; out AResponseCode: Integer);
+    function BuildAgentCard: string;
+    function ExtractUserText(AData: TJSONData): string;
+    function NewID: string;
+    function BuildMessageResponse(const AText: string): TJSONObject;
+    function HandleSendMessage(AParams: TJSONData; out AResult: TJSONObject;
+      out AError: string): Boolean;
+    function HandleJSONRPC(const AContent: string; out AResponse: string): Boolean;
+  protected
+    procedure Notification(AComponent: TComponent; Operation: TOperation); override;
+  public
+    constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+    function Start: Boolean;
+    procedure Stop;
+    property WebServer: TAIWebAPIServer read FWebServer;
+  published
+    property Agent: TAIAgent read FAgent write SetAgent;
+    property Port: Integer read FPort write FPort default 8090;
+    property PublicURL: string read FPublicURL write FPublicURL;
+    property AgentName: string read FAgentName write FAgentName;
+    property AgentDescription: string read FAgentDescription write FAgentDescription;
+    property AgentVersion: string read FAgentVersion write FAgentVersion;
+    property ProtocolVersion: string read FProtocolVersion write FProtocolVersion;
+    property SkillID: string read FSkillID write FSkillID;
+    property SkillName: string read FSkillName write FSkillName;
+    property Active: Boolean read FActive write SetActive default False;
+  end;
+
+procedure Register;
+
+implementation
+
+procedure Register;
+begin
+  RegisterComponents('AI A2A', [TAIA2AServer]);
+end;
+
+constructor TAIA2AServer.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FPort := 8090;
+  FPublicURL := 'http://127.0.0.1:8090';
+  FAgentName := 'Lazarus AI Agent';
+  FAgentDescription := 'Agent published by the CHATGPT Lazarus AI Suite.';
+  FAgentVersion := '1.0.0';
+  FProtocolVersion := '1.0';
+  FSkillID := 'chat';
+  FSkillName := 'Chat';
+  FWebServer := TAIWebAPIServer.Create(Self);
+  FWebServer.Port := FPort;
+  FWebServer.OnRequestReceived := @HandleRequest;
+end;
+
+destructor TAIA2AServer.Destroy;
+begin
+  Stop;
+  inherited Destroy;
+end;
+
+procedure TAIA2AServer.SetAgent(AValue: TAIAgent);
+begin
+  if FAgent = AValue then Exit;
+  if Assigned(FAgent) then FAgent.RemoveFreeNotification(Self);
+  FAgent := AValue;
+  if Assigned(FAgent) then FAgent.FreeNotification(Self);
+end;
+
+procedure TAIA2AServer.Notification(AComponent: TComponent; Operation: TOperation);
+begin
+  inherited Notification(AComponent, Operation);
+  if (Operation = opRemove) and (AComponent = FAgent) then FAgent := nil;
+end;
+
+procedure TAIA2AServer.SetActive(AValue: Boolean);
+begin
+  if FActive = AValue then Exit;
+  if AValue then Start else Stop;
+end;
+
+function TAIA2AServer.Start: Boolean;
+begin
+  ClearError;
+  if FAgent = nil then
+  begin
+    SetError('TAIA2AServer precisa de um TAIAgent configurado.');
+    Exit(False);
+  end;
+  FWebServer.Port := FPort;
+  Result := FWebServer.StartServer;
+  FActive := Result;
+  FLastSuccess := Result;
+  if not Result then SetError(FWebServer.LastError);
+end;
+
+procedure TAIA2AServer.Stop;
+begin
+  if Assigned(FWebServer) then FWebServer.StopServer;
+  FActive := False;
+end;
+
+function TAIA2AServer.NewID: string;
+var
+  G: TGUID;
+begin
+  if CreateGUID(G) = 0 then Result := GUIDToString(G)
+  else Result := IntToHex(Random(MaxInt), 8) + IntToHex(Random(MaxInt), 8);
+  Result := StringReplace(Result, '{', '', [rfReplaceAll]);
+  Result := StringReplace(Result, '}', '', [rfReplaceAll]);
+end;
+
+function TAIA2AServer.BuildAgentCard: string;
+var
+  Root, Caps, IntfHTTP, IntfRPC, Skill: TJSONObject;
+  Interfaces, Skills, Modes: TJSONArray;
+  Base: string;
+begin
+  Base := FPublicURL;
+  while (Base <> '') and (Base[Length(Base)] = '/') do Delete(Base, Length(Base), 1);
+  Root := TJSONObject.Create;
+  try
+    Root.Add('name', FAgentName);
+    Root.Add('description', FAgentDescription);
+    Root.Add('version', FAgentVersion);
+
+    Interfaces := TJSONArray.Create;
+    Root.Add('supportedInterfaces', Interfaces);
+    IntfHTTP := TJSONObject.Create;
+    IntfHTTP.Add('url', Base);
+    IntfHTTP.Add('protocolBinding', 'HTTP+JSON');
+    IntfHTTP.Add('protocolVersion', FProtocolVersion);
+    Interfaces.Add(IntfHTTP);
+    IntfRPC := TJSONObject.Create;
+    IntfRPC.Add('url', Base + '/rpc');
+    IntfRPC.Add('protocolBinding', 'JSONRPC');
+    IntfRPC.Add('protocolVersion', FProtocolVersion);
+    Interfaces.Add(IntfRPC);
+
+    Caps := TJSONObject.Create;
+    Caps.Add('streaming', False);
+    Caps.Add('pushNotifications', False);
+    Caps.Add('extendedAgentCard', False);
+    Root.Add('capabilities', Caps);
+
+    Modes := TJSONArray.Create;
+    Modes.Add('text/plain');
+    Root.Add('defaultInputModes', Modes);
+    Modes := TJSONArray.Create;
+    Modes.Add('text/plain');
+    Root.Add('defaultOutputModes', Modes);
+
+    Skills := TJSONArray.Create;
+    Root.Add('skills', Skills);
+    Skill := TJSONObject.Create;
+    Skill.Add('id', FSkillID);
+    Skill.Add('name', FSkillName);
+    Skill.Add('description', FAgentDescription);
+    Modes := TJSONArray.Create;
+    Modes.Add('text/plain');
+    Skill.Add('inputModes', Modes);
+    Modes := TJSONArray.Create;
+    Modes.Add('text/plain');
+    Skill.Add('outputModes', Modes);
+    Skills.Add(Skill);
+
+    Result := Root.AsJSON;
+  finally
+    Root.Free;
+  end;
+end;
+
+function TAIA2AServer.ExtractUserText(AData: TJSONData): string;
+var
+  Parts: TJSONData;
+  I: Integer;
+  S: string;
+begin
+  Result := '';
+  if AData = nil then Exit;
+  Parts := AData.FindPath('message.parts');
+  if (Parts = nil) or (Parts.JSONType <> jtArray) then Exit;
+  for I := 0 to TJSONArray(Parts).Count - 1 do
+  begin
+    S := '';
+    if TJSONArray(Parts).Items[I].FindPath('text') <> nil then
+      S := TJSONArray(Parts).Items[I].FindPath('text').AsString;
+    if S <> '' then
+    begin
+      if Result <> '' then Result := Result + LineEnding;
+      Result := Result + S;
+    end;
+  end;
+end;
+
+function TAIA2AServer.BuildMessageResponse(const AText: string): TJSONObject;
+var
+  Msg, Part: TJSONObject;
+  Parts: TJSONArray;
+begin
+  Result := TJSONObject.Create;
+  Msg := TJSONObject.Create;
+  Result.Add('message', Msg);
+  Msg.Add('messageId', NewID);
+  Msg.Add('role', 'ROLE_AGENT');
+  Parts := TJSONArray.Create;
+  Msg.Add('parts', Parts);
+  Part := TJSONObject.Create;
+  Part.Add('text', AText);
+  Parts.Add(Part);
+end;
+
+function TAIA2AServer.HandleSendMessage(AParams: TJSONData;
+  out AResult: TJSONObject; out AError: string): Boolean;
+var
+  InputText: string;
+begin
+  Result := False;
+  AResult := nil;
+  AError := '';
+  if FAgent = nil then
+  begin
+    AError := 'Agent nao configurado.';
+    Exit;
+  end;
+  InputText := ExtractUserText(AParams);
+  if Trim(InputText) = '' then
+  begin
+    AError := 'message.parts precisa conter texto.';
+    Exit;
+  end;
+  if not FAgent.Execute(InputText) then
+  begin
+    AError := FAgent.LastError;
+    if AError = '' then AError := 'Falha ao executar agente.';
+    Exit;
+  end;
+  AResult := BuildMessageResponse(FAgent.LastResult);
+  Result := True;
+end;
+
+function TAIA2AServer.HandleJSONRPC(const AContent: string;
+  out AResponse: string): Boolean;
+var
+  Root, Params: TJSONData;
+  OutRoot, ResultObj, ErrObj: TJSONObject;
+  MethodName, RequestID, ErrText: string;
+begin
+  Result := False;
+  AResponse := '';
+  try
+    Root := GetJSON(AContent);
+    try
+      MethodName := '';
+      RequestID := '';
+      if Root.FindPath('method') <> nil then MethodName := Root.FindPath('method').AsString;
+      if Root.FindPath('id') <> nil then RequestID := Root.FindPath('id').AsString;
+      Params := Root.FindPath('params');
+      OutRoot := TJSONObject.Create;
+      try
+        OutRoot.Add('jsonrpc', '2.0');
+        OutRoot.Add('id', RequestID);
+        if SameText(MethodName, 'SendMessage') then
+        begin
+          if HandleSendMessage(Params, ResultObj, ErrText) then
+          begin
+            OutRoot.Add('result', ResultObj);
+            Result := True;
+          end
+          else
+          begin
+            ErrObj := TJSONObject.Create;
+            ErrObj.Add('code', -32602);
+            ErrObj.Add('message', ErrText);
+            OutRoot.Add('error', ErrObj);
+          end;
+        end
+        else
+        begin
+          ErrObj := TJSONObject.Create;
+          ErrObj.Add('code', -32601);
+          ErrObj.Add('message', 'Method not found');
+          OutRoot.Add('error', ErrObj);
+        end;
+        AResponse := OutRoot.AsJSON;
+      finally
+        OutRoot.Free;
+      end;
+    finally
+      Root.Free;
+    end;
+  except
+    on E: Exception do
+    begin
+      OutRoot := TJSONObject.Create;
+      try
+        OutRoot.Add('jsonrpc', '2.0');
+        OutRoot.Add('id', TJSONNull.Create);
+        ErrObj := TJSONObject.Create;
+        ErrObj.Add('code', -32700);
+        ErrObj.Add('message', 'Invalid JSON payload: ' + E.Message);
+        OutRoot.Add('error', ErrObj);
+        AResponse := OutRoot.AsJSON;
+      finally
+        OutRoot.Free;
+      end;
+    end;
+  end;
+end;
+
+procedure TAIA2AServer.HandleRequest(Sender: TObject; const ARoute, AMethod,
+  AContent: string; out AResponse: string; out AResponseCode: Integer);
+var
+  Data: TJSONData;
+  ResultObj: TJSONObject;
+  ErrText: string;
+begin
+  AResponseCode := 200;
+  if SameText(AMethod, 'GET') and
+     SameText(ARoute, '/.well-known/agent-card.json') then
+  begin
+    AResponse := BuildAgentCard;
+    Exit;
+  end;
+
+  if SameText(AMethod, 'POST') and SameText(ARoute, '/rpc') then
+  begin
+    if not HandleJSONRPC(AContent, AResponse) then
+      AResponseCode := 400;
+    Exit;
+  end;
+
+  if SameText(AMethod, 'POST') and SameText(ARoute, '/message:send') then
+  begin
+    try
+      Data := GetJSON(AContent);
+      try
+        if HandleSendMessage(Data, ResultObj, ErrText) then
+        begin
+          try
+            AResponse := ResultObj.AsJSON;
+          finally
+            ResultObj.Free;
+          end;
+        end
+        else
+        begin
+          AResponseCode := 400;
+          ResultObj := TJSONObject.Create;
+          try
+            ResultObj.Add('error', ErrText);
+            AResponse := ResultObj.AsJSON;
+          finally
+            ResultObj.Free;
+          end;
+        end;
+      finally
+        Data.Free;
+      end;
+    except
+      on E: Exception do
+      begin
+        AResponseCode := 400;
+        AResponse := '{"error":"' + StringReplace(E.Message, '"', '\"', [rfReplaceAll]) + '"}';
+      end;
+    end;
+    Exit;
+  end;
+
+  AResponseCode := 404;
+  AResponse := '{"error":"A2A route not found"}';
+end;
+
+end.

--- a/pacote/AI Agent/aicommonserviceagents.pas
+++ b/pacote/AI Agent/aicommonserviceagents.pas
@@ -1,0 +1,795 @@
+unit aicommonserviceagents;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, StrUtils, fphttpclient, opensslsockets, DB, SQLDB,
+  LResources, aibase, aiprocessrunner, aiemail;
+
+type
+  TAIServiceAgent = class(TAIBaseComponent)
+  private
+    FAccessToken: string;
+    FBaseURL: string;
+    FAllowRead: Boolean;
+    FAllowWrite: Boolean;
+    FTimeoutMs: Integer;
+    FLastStatusCode: Integer;
+  protected
+    function EnsureRead: Boolean;
+    function EnsureWrite: Boolean;
+    function Request(const AMethod, AURL, ABody, AContentType,
+      AHeaderName, AHeaderValue: string): Boolean;
+    function JoinURL(const APath: string): string;
+    function URLEncode(const S: string): string;
+    function JSONEscape(const S: string): string;
+  public
+    constructor Create(AOwner: TComponent); override;
+    property LastStatusCode: Integer read FLastStatusCode;
+  published
+    property AccessToken: string read FAccessToken write FAccessToken;
+    property BaseURL: string read FBaseURL write FBaseURL;
+    property AllowRead: Boolean read FAllowRead write FAllowRead default True;
+    property AllowWrite: Boolean read FAllowWrite write FAllowWrite default False;
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 30000;
+  end;
+
+  TAIGitLabAgent = class(TAIServiceAgent)
+  private
+    FProjectID: string;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function GetProject: Boolean;
+    function ListIssues: Boolean;
+    function CreateIssue(const ATitle, ADescription: string): Boolean;
+    function ListPipelines: Boolean;
+  published
+    property ProjectID: string read FProjectID write FProjectID;
+  end;
+
+  TAITelegramAgent = class(TAIServiceAgent)
+  private
+    FBotToken: string;
+    FChatID: string;
+    function BotURL(const AMethod: string): string;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function GetMe: Boolean;
+    function GetUpdates(AOffset: Int64 = 0): Boolean;
+    function SendMessage(const AText: string): Boolean;
+  published
+    property BotToken: string read FBotToken write FBotToken;
+    property ChatID: string read FChatID write FChatID;
+  end;
+
+  TAIEmailAgent = class(TAIServiceAgent)
+  private
+    FClient: TAIEmailClient;
+    FHostSMTP: string;
+    FPortSMTP: Integer;
+    FHostPOP3: string;
+    FPortPOP3: Integer;
+    FUsername: string;
+    FPassword: string;
+    procedure ApplySettings;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function SendEmail(const ATo, ASubject, ABody: string): Boolean;
+    function FetchEmails: Boolean;
+  published
+    property HostSMTP: string read FHostSMTP write FHostSMTP;
+    property PortSMTP: Integer read FPortSMTP write FPortSMTP default 25;
+    property HostPOP3: string read FHostPOP3 write FHostPOP3;
+    property PortPOP3: Integer read FPortPOP3 write FPortPOP3 default 110;
+    property Username: string read FUsername write FUsername;
+    property Password: string read FPassword write FPassword;
+  end;
+
+  TAIRSSAgent = class(TAIServiceAgent)
+  private
+    FFeedURL: string;
+    function ExtractTitles(const AXML: string): string;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function Fetch: Boolean;
+    function FetchTitles: Boolean;
+  published
+    property FeedURL: string read FFeedURL write FFeedURL;
+  end;
+
+  TAIWebAgent = class(TAIServiceAgent)
+  public
+    constructor Create(AOwner: TComponent); override;
+    function Get(const AURL: string): Boolean;
+    function PostJSON(const AURL, AJSON: string): Boolean;
+    function DownloadFile(const AURL, AFileName: string): Boolean;
+  end;
+
+  TAISSHAgent = class(TAIServiceAgent)
+  private
+    FRunner: TAIProcessRunner;
+    FSSHPath: string;
+    FHost: string;
+    FUserName: string;
+    FPort: Integer;
+    FIdentityFile: string;
+    function GetStdOutText: string;
+    function GetStdErrText: string;
+    function GetExitCode: Integer;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function ExecuteCommand(const ACommand: string): Boolean;
+    procedure Stop;
+    property StdOutText: string read GetStdOutText;
+    property StdErrText: string read GetStdErrText;
+    property ExitCode: Integer read GetExitCode;
+  published
+    property SSHPath: string read FSSHPath write FSSHPath;
+    property Host: string read FHost write FHost;
+    property UserName: string read FUserName write FUserName;
+    property Port: Integer read FPort write FPort default 22;
+    property IdentityFile: string read FIdentityFile write FIdentityFile;
+  end;
+
+  TAIDatabaseAgent = class(TAIServiceAgent)
+  private
+    FConnection: TSQLConnection;
+    procedure SetConnection(AValue: TSQLConnection);
+    function IsReadOnlySQL(const ASQL: string): Boolean;
+  protected
+    procedure Notification(AComponent: TComponent; Operation: TOperation); override;
+  public
+    function ExecuteReadOnly(const ASQL: string): Boolean;
+    function ExecuteNonQuery(const ASQL: string): Boolean;
+  published
+    property Connection: TSQLConnection read FConnection write SetConnection;
+  end;
+
+  TAIWhatsAppAgent = class(TAIServiceAgent)
+  private
+    FAPIVersion: string;
+    FPhoneNumberID: string;
+    function MessagesURL: string;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function GetPhoneNumberInfo: Boolean;
+    function SendText(const AToPhone, AText: string): Boolean;
+    function MarkAsRead(const AMessageID: string): Boolean;
+  published
+    property APIVersion: string read FAPIVersion write FAPIVersion;
+    property PhoneNumberID: string read FPhoneNumberID write FPhoneNumberID;
+  end;
+
+procedure Register;
+
+implementation
+
+procedure Register;
+begin
+  RegisterComponents('AI Services', [TAIGitLabAgent, TAITelegramAgent,
+    TAIEmailAgent, TAIRSSAgent, TAIWebAgent, TAISSHAgent,
+    TAIDatabaseAgent, TAIWhatsAppAgent]);
+end;
+
+{ TAIServiceAgent }
+
+constructor TAIServiceAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FAllowRead := True;
+  FAllowWrite := False;
+  FTimeoutMs := 30000;
+  FLastStatusCode := 0;
+end;
+
+function TAIServiceAgent.EnsureRead: Boolean;
+begin
+  Result := FAllowRead;
+  if not Result then SetError('AllowRead=False. Leitura bloqueada.');
+end;
+
+function TAIServiceAgent.EnsureWrite: Boolean;
+begin
+  Result := FAllowWrite;
+  if not Result then SetError('AllowWrite=False. Escrita bloqueada.');
+end;
+
+function TAIServiceAgent.JoinURL(const APath: string): string;
+begin
+  if APath = '' then Exit(FBaseURL);
+  if AnsiEndsStr('/', FBaseURL) and AnsiStartsStr('/', APath) then
+    Result := FBaseURL + Copy(APath, 2, MaxInt)
+  else if (not AnsiEndsStr('/', FBaseURL)) and (not AnsiStartsStr('/', APath)) then
+    Result := FBaseURL + '/' + APath
+  else
+    Result := FBaseURL + APath;
+end;
+
+function TAIServiceAgent.URLEncode(const S: string): string;
+const
+  Hex: array[0..15] of Char = '0123456789ABCDEF';
+var
+  I: Integer;
+  C: Byte;
+begin
+  Result := '';
+  for I := 1 to Length(S) do
+  begin
+    C := Ord(S[I]);
+    if ((C >= Ord('a')) and (C <= Ord('z'))) or
+       ((C >= Ord('A')) and (C <= Ord('Z'))) or
+       ((C >= Ord('0')) and (C <= Ord('9'))) or (S[I] in ['-', '_', '.', '~']) then
+      Result := Result + S[I]
+    else
+      Result := Result + '%' + Hex[C shr 4] + Hex[C and $0F];
+  end;
+end;
+
+function TAIServiceAgent.JSONEscape(const S: string): string;
+var
+  I: Integer;
+begin
+  Result := '';
+  for I := 1 to Length(S) do
+    case S[I] of
+      '"': Result := Result + '\"';
+      '\': Result := Result + '\\';
+      #8: Result := Result + '\b';
+      #9: Result := Result + '\t';
+      #10: Result := Result + '\n';
+      #12: Result := Result + '\f';
+      #13: Result := Result + '\r';
+    else
+      Result := Result + S[I];
+    end;
+end;
+
+function TAIServiceAgent.Request(const AMethod, AURL, ABody, AContentType,
+  AHeaderName, AHeaderValue: string): Boolean;
+var
+  Client: TFPHTTPClient;
+  RequestStream, ResponseStream: TStringStream;
+  URL: string;
+begin
+  ClearError;
+  Result := False;
+  FLastStatusCode := 0;
+  URL := AURL;
+  if URL = '' then
+  begin
+    SetError('URL nao configurada.');
+    Exit;
+  end;
+  Client := TFPHTTPClient.Create(nil);
+  RequestStream := nil;
+  ResponseStream := TStringStream.Create('');
+  try
+    Client.ConnectTimeout := FTimeoutMs;
+    Client.IOTimeout := FTimeoutMs;
+    Client.AllowRedirect := True;
+    if AContentType <> '' then Client.AddHeader('Content-Type', AContentType);
+    Client.AddHeader('Accept', 'application/json, application/xml, text/xml, text/plain, */*');
+    if (AHeaderName <> '') and (AHeaderValue <> '') then
+      Client.AddHeader(AHeaderName, AHeaderValue);
+    if ABody <> '' then
+    begin
+      RequestStream := TStringStream.Create(ABody);
+      Client.RequestBody := RequestStream;
+    end;
+    try
+      Client.HTTPMethod(UpperCase(AMethod), URL, ResponseStream, [200, 201, 202, 204]);
+      FLastStatusCode := Client.ResponseStatusCode;
+      FLastResult := ResponseStream.DataString;
+      FLastSuccess := True;
+      Result := True;
+    except
+      on E: Exception do
+      begin
+        FLastStatusCode := Client.ResponseStatusCode;
+        FLastResult := ResponseStream.DataString;
+        SetError(E.Message);
+      end;
+    end;
+  finally
+    RequestStream.Free;
+    ResponseStream.Free;
+    Client.Free;
+  end;
+end;
+
+{ TAIGitLabAgent }
+
+constructor TAIGitLabAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  BaseURL := 'https://gitlab.com/api/v4';
+end;
+
+function TAIGitLabAgent.GetProject: Boolean;
+begin
+  if not EnsureRead then Exit(False);
+  Result := Request('GET', JoinURL('/projects/' + URLEncode(FProjectID)), '', '',
+    'PRIVATE-TOKEN', AccessToken);
+end;
+
+function TAIGitLabAgent.ListIssues: Boolean;
+begin
+  if not EnsureRead then Exit(False);
+  Result := Request('GET', JoinURL('/projects/' + URLEncode(FProjectID) + '/issues'), '', '',
+    'PRIVATE-TOKEN', AccessToken);
+end;
+
+function TAIGitLabAgent.CreateIssue(const ATitle, ADescription: string): Boolean;
+var
+  Body: string;
+begin
+  if not EnsureWrite then Exit(False);
+  Body := '{"title":"' + JSONEscape(ATitle) + '","description":"' +
+    JSONEscape(ADescription) + '"}';
+  Result := Request('POST', JoinURL('/projects/' + URLEncode(FProjectID) + '/issues'),
+    Body, 'application/json', 'PRIVATE-TOKEN', AccessToken);
+end;
+
+function TAIGitLabAgent.ListPipelines: Boolean;
+begin
+  if not EnsureRead then Exit(False);
+  Result := Request('GET', JoinURL('/projects/' + URLEncode(FProjectID) + '/pipelines'), '', '',
+    'PRIVATE-TOKEN', AccessToken);
+end;
+
+{ TAITelegramAgent }
+
+constructor TAITelegramAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  BaseURL := 'https://api.telegram.org';
+end;
+
+function TAITelegramAgent.BotURL(const AMethod: string): string;
+begin
+  Result := JoinURL('/bot' + FBotToken + '/' + AMethod);
+end;
+
+function TAITelegramAgent.GetMe: Boolean;
+begin
+  if not EnsureRead then Exit(False);
+  Result := Request('GET', BotURL('getMe'), '', '', '', '');
+end;
+
+function TAITelegramAgent.GetUpdates(AOffset: Int64): Boolean;
+var
+  URL: string;
+begin
+  if not EnsureRead then Exit(False);
+  URL := BotURL('getUpdates');
+  if AOffset <> 0 then URL := URL + '?offset=' + IntToStr(AOffset);
+  Result := Request('GET', URL, '', '', '', '');
+end;
+
+function TAITelegramAgent.SendMessage(const AText: string): Boolean;
+var
+  Body: string;
+begin
+  if not EnsureWrite then Exit(False);
+  Body := '{"chat_id":"' + JSONEscape(FChatID) + '","text":"' + JSONEscape(AText) + '"}';
+  Result := Request('POST', BotURL('sendMessage'), Body, 'application/json', '', '');
+end;
+
+{ TAIEmailAgent }
+
+constructor TAIEmailAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FPortSMTP := 25;
+  FPortPOP3 := 110;
+  FClient := TAIEmailClient.Create(Self);
+end;
+
+procedure TAIEmailAgent.ApplySettings;
+begin
+  FClient.HostSMTP := FHostSMTP;
+  FClient.PortSMTP := FPortSMTP;
+  FClient.HostPOP3 := FHostPOP3;
+  FClient.PortPOP3 := FPortPOP3;
+  FClient.Username := FUsername;
+  FClient.Password := FPassword;
+end;
+
+function TAIEmailAgent.SendEmail(const ATo, ASubject, ABody: string): Boolean;
+begin
+  ClearError;
+  if not EnsureWrite then Exit(False);
+  ApplySettings;
+  Result := FClient.SendEmail(ATo, ASubject, ABody);
+  FLastSuccess := Result;
+  if Result then FLastResult := 'E-mail enviado para ' + ATo
+  else SetError('Falha ao enviar e-mail.');
+end;
+
+function TAIEmailAgent.FetchEmails: Boolean;
+var
+  Emails: TStrings;
+begin
+  ClearError;
+  if not EnsureRead then Exit(False);
+  ApplySettings;
+  Emails := nil;
+  Result := FClient.FetchEmails(Emails);
+  try
+    if Result and Assigned(Emails) then
+    begin
+      FLastResult := Emails.Text;
+      FLastSuccess := True;
+    end
+    else if not Result then
+      SetError('Falha ao buscar e-mails.');
+  finally
+    Emails.Free;
+  end;
+end;
+
+{ TAIRSSAgent }
+
+constructor TAIRSSAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+end;
+
+function TAIRSSAgent.Fetch: Boolean;
+begin
+  if not EnsureRead then Exit(False);
+  Result := Request('GET', FFeedURL, '', '', '', '');
+end;
+
+function TAIRSSAgent.ExtractTitles(const AXML: string): string;
+var
+  P, P1, P2: SizeInt;
+  S, Segment, Title: string;
+begin
+  Result := '';
+  S := AXML;
+  P := 1;
+  while P <= Length(S) do
+  begin
+    P1 := PosEx('<item', S, P);
+    if P1 = 0 then Break;
+    P1 := PosEx('>', S, P1);
+    if P1 = 0 then Break;
+    P2 := PosEx('</item>', S, P1 + 1);
+    if P2 = 0 then Break;
+    Segment := Copy(S, P1 + 1, P2 - P1 - 1);
+    P1 := Pos('<title>', Segment);
+    if P1 > 0 then
+    begin
+      P1 := P1 + Length('<title>');
+      P2 := PosEx('</title>', Segment, P1);
+      if P2 > 0 then
+      begin
+        Title := Trim(Copy(Segment, P1, P2 - P1));
+        Result := Result + Title + LineEnding;
+      end;
+    end;
+    P := P2 + Length('</item>');
+  end;
+  if Result = '' then
+  begin
+    P := 1;
+    while P <= Length(S) do
+    begin
+      P1 := PosEx('<entry', S, P);
+      if P1 = 0 then Break;
+      P1 := PosEx('>', S, P1);
+      if P1 = 0 then Break;
+      P2 := PosEx('</entry>', S, P1 + 1);
+      if P2 = 0 then Break;
+      Segment := Copy(S, P1 + 1, P2 - P1 - 1);
+      P1 := Pos('<title', Segment);
+      if P1 > 0 then
+      begin
+        P1 := PosEx('>', Segment, P1) + 1;
+        if P1 > 1 then
+        begin
+          P2 := PosEx('</title>', Segment, P1);
+          if P2 > 0 then
+            Result := Result + Trim(Copy(Segment, P1, P2 - P1)) + LineEnding;
+        end;
+      end;
+      P := P2 + Length('</entry>');
+    end;
+  end;
+end;
+
+function TAIRSSAgent.FetchTitles: Boolean;
+var
+  XML: string;
+begin
+  Result := Fetch;
+  if not Result then Exit;
+  XML := FLastResult;
+  FLastResult := ExtractTitles(XML);
+  Result := Trim(FLastResult) <> '';
+  FLastSuccess := Result;
+  if not Result then SetError('Nenhum titulo RSS/Atom encontrado.');
+end;
+
+{ TAIWebAgent }
+
+constructor TAIWebAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+end;
+
+function TAIWebAgent.Get(const AURL: string): Boolean;
+begin
+  if not EnsureRead then Exit(False);
+  Result := Request('GET', AURL, '', '', '', '');
+end;
+
+function TAIWebAgent.PostJSON(const AURL, AJSON: string): Boolean;
+begin
+  if not EnsureWrite then Exit(False);
+  Result := Request('POST', AURL, AJSON, 'application/json', '', '');
+end;
+
+function TAIWebAgent.DownloadFile(const AURL, AFileName: string): Boolean;
+var
+  Client: TFPHTTPClient;
+  Stream: TFileStream;
+begin
+  ClearError;
+  if not EnsureRead then Exit(False);
+  if not EnsureWrite then Exit(False);
+  Result := False;
+  Client := TFPHTTPClient.Create(nil);
+  Stream := nil;
+  try
+    Client.ConnectTimeout := TimeoutMs;
+    Client.IOTimeout := TimeoutMs;
+    Stream := TFileStream.Create(AFileName, fmCreate);
+    try
+      Client.Get(AURL, Stream);
+      FLastResult := ExpandFileName(AFileName);
+      FLastSuccess := True;
+      Result := True;
+    except
+      on E: Exception do SetError(E.Message);
+    end;
+  finally
+    Stream.Free;
+    Client.Free;
+  end;
+end;
+
+{ TAISSHAgent }
+
+constructor TAISSHAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FSSHPath := 'ssh';
+  FPort := 22;
+  FRunner := TAIProcessRunner.Create(Self);
+end;
+
+function TAISSHAgent.GetStdOutText: string;
+begin
+  Result := FRunner.StdOutText;
+end;
+
+function TAISSHAgent.GetStdErrText: string;
+begin
+  Result := FRunner.StdErrText;
+end;
+
+function TAISSHAgent.GetExitCode: Integer;
+begin
+  Result := FRunner.LastExitCode;
+end;
+
+function TAISSHAgent.ExecuteCommand(const ACommand: string): Boolean;
+var
+  Params: array of string;
+  Target: string;
+  N: Integer;
+begin
+  ClearError;
+  if not EnsureWrite then Exit(False);
+  if Trim(FHost) = '' then
+  begin
+    SetError('Host nao configurado.');
+    Exit(False);
+  end;
+  Target := FHost;
+  if Trim(FUserName) <> '' then Target := FUserName + '@' + FHost;
+  SetLength(Params, 0);
+  N := 0;
+  SetLength(Params, N + 2); Params[N] := '-o'; Params[N + 1] := 'BatchMode=yes'; Inc(N, 2);
+  SetLength(Params, N + 2); Params[N] := '-p'; Params[N + 1] := IntToStr(FPort); Inc(N, 2);
+  if Trim(FIdentityFile) <> '' then
+  begin
+    SetLength(Params, N + 2); Params[N] := '-i'; Params[N + 1] := FIdentityFile; Inc(N, 2);
+  end;
+  SetLength(Params, N + 2); Params[N] := Target; Params[N + 1] := ACommand;
+  FRunner.Executable := FSSHPath;
+  FRunner.TimeoutMs := TimeoutMs;
+  Result := FRunner.Execute(Params);
+  FLastSuccess := Result;
+  FLastResult := FRunner.StdOutText;
+  if not Result then SetError(FRunner.LastError);
+end;
+
+procedure TAISSHAgent.Stop;
+begin
+  FRunner.Stop;
+end;
+
+{ TAIDatabaseAgent }
+
+procedure TAIDatabaseAgent.SetConnection(AValue: TSQLConnection);
+begin
+  if FConnection = AValue then Exit;
+  if Assigned(FConnection) then FConnection.RemoveFreeNotification(Self);
+  FConnection := AValue;
+  if Assigned(FConnection) then FConnection.FreeNotification(Self);
+end;
+
+procedure TAIDatabaseAgent.Notification(AComponent: TComponent; Operation: TOperation);
+begin
+  inherited Notification(AComponent, Operation);
+  if (Operation = opRemove) and (AComponent = FConnection) then FConnection := nil;
+end;
+
+function TAIDatabaseAgent.IsReadOnlySQL(const ASQL: string): Boolean;
+var
+  S: string;
+begin
+  S := UpperCase(Trim(ASQL));
+  Result := AnsiStartsStr('SELECT', S) or AnsiStartsStr('WITH', S) or
+    AnsiStartsStr('EXPLAIN', S) or AnsiStartsStr('SHOW', S);
+end;
+
+function TAIDatabaseAgent.ExecuteReadOnly(const ASQL: string): Boolean;
+var
+  Q: TSQLQuery;
+  I: Integer;
+  Row: string;
+begin
+  ClearError;
+  if not EnsureRead then Exit(False);
+  if not IsReadOnlySQL(ASQL) then
+  begin
+    SetError('SQL nao permitido em ExecuteReadOnly.');
+    Exit(False);
+  end;
+  if FConnection = nil then
+  begin
+    SetError('Connection nao configurada.');
+    Exit(False);
+  end;
+  Q := TSQLQuery.Create(nil);
+  try
+    Q.DataBase := FConnection;
+    Q.SQL.Text := ASQL;
+    try
+      Q.Open;
+      FLastResult := '';
+      while not Q.EOF do
+      begin
+        Row := '';
+        for I := 0 to Q.Fields.Count - 1 do
+        begin
+          if I > 0 then Row := Row + #9;
+          Row := Row + Q.Fields[I].FieldName + '=' + Q.Fields[I].AsString;
+        end;
+        FLastResult := FLastResult + Row + LineEnding;
+        Q.Next;
+      end;
+      FLastSuccess := True;
+      Result := True;
+    except
+      on E: Exception do begin SetError(E.Message); Result := False; end;
+    end;
+  finally
+    Q.Free;
+  end;
+end;
+
+function TAIDatabaseAgent.ExecuteNonQuery(const ASQL: string): Boolean;
+var
+  Q: TSQLQuery;
+  T: TSQLTransaction;
+  OwnTransaction: Boolean;
+begin
+  ClearError;
+  if not EnsureWrite then Exit(False);
+  if FConnection = nil then
+  begin
+    SetError('Connection nao configurada.');
+    Exit(False);
+  end;
+  Q := TSQLQuery.Create(nil);
+  T := nil;
+  OwnTransaction := FConnection.Transaction = nil;
+  try
+    if OwnTransaction then
+    begin
+      T := TSQLTransaction.Create(nil);
+      T.DataBase := FConnection;
+      FConnection.Transaction := T;
+    end;
+    Q.DataBase := FConnection;
+    Q.Transaction := FConnection.Transaction;
+    Q.SQL.Text := ASQL;
+    try
+      if not FConnection.Transaction.Active then FConnection.Transaction.StartTransaction;
+      Q.ExecSQL;
+      FConnection.Transaction.Commit;
+      FLastResult := 'SQL executado. RowsAffected=' + IntToStr(Q.RowsAffected);
+      FLastSuccess := True;
+      Result := True;
+    except
+      on E: Exception do
+      begin
+        if Assigned(FConnection.Transaction) and FConnection.Transaction.Active then
+          FConnection.Transaction.Rollback;
+        SetError(E.Message);
+        Result := False;
+      end;
+    end;
+  finally
+    Q.Free;
+    if OwnTransaction then
+    begin
+      FConnection.Transaction := nil;
+      T.Free;
+    end;
+  end;
+end;
+
+{ TAIWhatsAppAgent }
+
+constructor TAIWhatsAppAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  BaseURL := 'https://graph.facebook.com';
+  FAPIVersion := 'v23.0';
+end;
+
+function TAIWhatsAppAgent.MessagesURL: string;
+begin
+  Result := JoinURL('/' + FAPIVersion + '/' + FPhoneNumberID + '/messages');
+end;
+
+function TAIWhatsAppAgent.GetPhoneNumberInfo: Boolean;
+begin
+  if not EnsureRead then Exit(False);
+  Result := Request('GET', JoinURL('/' + FAPIVersion + '/' + FPhoneNumberID), '', '',
+    'Authorization', 'Bearer ' + AccessToken);
+end;
+
+function TAIWhatsAppAgent.SendText(const AToPhone, AText: string): Boolean;
+var
+  Body: string;
+begin
+  if not EnsureWrite then Exit(False);
+  Body := '{"messaging_product":"whatsapp","recipient_type":"individual",' +
+    '"to":"' + JSONEscape(AToPhone) + '","type":"text","text":{"preview_url":false,' +
+    '"body":"' + JSONEscape(AText) + '"}}';
+  Result := Request('POST', MessagesURL, Body, 'application/json',
+    'Authorization', 'Bearer ' + AccessToken);
+end;
+
+function TAIWhatsAppAgent.MarkAsRead(const AMessageID: string): Boolean;
+var
+  Body: string;
+begin
+  if not EnsureWrite then Exit(False);
+  Body := '{"messaging_product":"whatsapp","status":"read","message_id":"' +
+    JSONEscape(AMessageID) + '"}';
+  Result := Request('POST', MessagesURL, Body, 'application/json',
+    'Authorization', 'Bearer ' + AccessToken);
+end;
+
+end.

--- a/pacote/AI Agent/aidevagents.pas
+++ b/pacote/AI Agent/aidevagents.pas
@@ -21,6 +21,7 @@ type
     function ResolveFile(const AFileName: string; out AResolved: string): Boolean;
     function ReadTextFile(const AFileName: string; out AText: string): Boolean;
     function StripCodeFence(const AText: string): string;
+    function CopyFileSafe(const ASource, ADest: string): Boolean;
   protected
     procedure Notification(AComponent: TComponent; Operation: TOperation); override;
   public
@@ -45,13 +46,16 @@ type
     FBuildMode: string;
     FWorkingDirectory: string;
     FTimeoutMs: Integer;
+    function GetStdOutText: string;
+    function GetStdErrText: string;
+    function GetExitCode: Integer;
   public
     constructor Create(AOwner: TComponent); override;
     function Build: Boolean;
     procedure Stop;
-    property StdOutText: string read FRunner.StdOutText;
-    property StdErrText: string read FRunner.StdErrText;
-    property ExitCode: Integer read FRunner.LastExitCode;
+    property StdOutText: string read GetStdOutText;
+    property StdErrText: string read GetStdErrText;
+    property ExitCode: Integer read GetExitCode;
   published
     property LazBuildPath: string read FLazBuildPath write FLazBuildPath;
     property ProjectFile: string read FProjectFile write FProjectFile;
@@ -68,13 +72,16 @@ type
     FArguments: string;
     FTimeoutMs: Integer;
     function SplitArguments(const S: string): TStringList;
+    function GetStdOutText: string;
+    function GetStdErrText: string;
+    function GetExitCode: Integer;
   public
     constructor Create(AOwner: TComponent); override;
     function Run: Boolean;
     procedure Stop;
-    property StdOutText: string read FRunner.StdOutText;
-    property StdErrText: string read FRunner.StdErrText;
-    property ExitCode: Integer read FRunner.LastExitCode;
+    property StdOutText: string read GetStdOutText;
+    property StdErrText: string read GetStdErrText;
+    property ExitCode: Integer read GetExitCode;
   published
     property Executable: string read FExecutable write FExecutable;
     property WorkingDirectory: string read FWorkingDirectory write FWorkingDirectory;
@@ -120,6 +127,8 @@ begin
   {$ENDIF}
 end;
 
+{ TAISourceAgent }
+
 constructor TAISourceAgent.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
@@ -148,6 +157,7 @@ function TAISourceAgent.ResolveFile(const AFileName: string;
   out AResolved: string): Boolean;
 begin
   ClearError;
+  AResolved := '';
   if Trim(FRootDirectory) = '' then
   begin
     SetError('RootDirectory nao configurado.');
@@ -187,6 +197,29 @@ begin
   end;
 end;
 
+function TAISourceAgent.CopyFileSafe(const ASource, ADest: string): Boolean;
+var
+  SourceStream, DestStream: TFileStream;
+begin
+  Result := False;
+  try
+    SourceStream := TFileStream.Create(ASource, fmOpenRead or fmShareDenyWrite);
+    try
+      DestStream := TFileStream.Create(ADest, fmCreate);
+      try
+        DestStream.CopyFrom(SourceStream, 0);
+        Result := True;
+      finally
+        DestStream.Free;
+      end;
+    finally
+      SourceStream.Free;
+    end;
+  except
+    Result := False;
+  end;
+end;
+
 function TAISourceAgent.StripCodeFence(const AText: string): string;
 var
   S: string;
@@ -196,11 +229,8 @@ begin
   if Pos('```', S) <> 1 then Exit(AText);
   P := Pos(LineEnding, S);
   if P > 0 then Delete(S, 1, P + Length(LineEnding) - 1);
-  if RightStr(TrimRight(S), 3) = '```' then
-  begin
-    S := TrimRight(S);
-    Delete(S, Length(S) - 2, 3);
-  end;
+  S := TrimRight(S);
+  if RightStr(S, 3) = '```' then Delete(S, Length(S) - 2, 3);
   Result := S;
 end;
 
@@ -249,6 +279,7 @@ begin
   end;
   if not ResolveFile(AFileName, FileName) then Exit;
   if not ReadTextFile(FileName, Source) then Exit;
+
   PromptText := 'Reescreva o arquivo Lazarus/Free Pascal conforme a orientacao. ' +
     'Preserve compatibilidade e todo codigo nao relacionado. Retorne SOMENTE o fonte completo, sem markdown.' +
     LineEnding + 'ORIENTACAO:' + LineEnding + AInstruction + LineEnding +
@@ -258,6 +289,7 @@ begin
     SetError(FLLM.LastError);
     Exit;
   end;
+
   NewSource := StripCodeFence(FLLM.LastResult);
   if Trim(NewSource) = '' then
   begin
@@ -268,8 +300,12 @@ begin
   if FCreateBackup then
   begin
     BackupName := FileName + FBackupExtension;
-    if FileExists(BackupName) then DeleteFile(BackupName);
-    if not CopyFile(FileName, BackupName) then
+    if FileExists(BackupName) and (not DeleteFile(BackupName)) then
+    begin
+      SetError('Nao foi possivel substituir backup: ' + BackupName);
+      Exit;
+    end;
+    if not CopyFileSafe(FileName, BackupName) then
     begin
       SetError('Nao foi possivel criar backup: ' + BackupName);
       Exit;
@@ -310,7 +346,7 @@ begin
     SetError('Backup nao encontrado: ' + BackupName);
     Exit;
   end;
-  Result := CopyFile(BackupName, FileName);
+  Result := CopyFileSafe(BackupName, FileName);
   if Result then
   begin
     FLastSuccess := True;
@@ -319,6 +355,8 @@ begin
   else
     SetError('Falha ao restaurar backup.');
 end;
+
+{ TAILazarusBuildAgent }
 
 constructor TAILazarusBuildAgent.Create(AOwner: TComponent);
 begin
@@ -329,9 +367,25 @@ begin
   FRunner := TAIProcessRunner.Create(Self);
 end;
 
+function TAILazarusBuildAgent.GetStdOutText: string;
+begin
+  Result := FRunner.StdOutText;
+end;
+
+function TAILazarusBuildAgent.GetStdErrText: string;
+begin
+  Result := FRunner.StdErrText;
+end;
+
+function TAILazarusBuildAgent.GetExitCode: Integer;
+begin
+  Result := FRunner.LastExitCode;
+end;
+
 function TAILazarusBuildAgent.Build: Boolean;
 var
   Params: array of string;
+  ProjectPath: string;
 begin
   ClearError;
   if Trim(FProjectFile) = '' then
@@ -339,21 +393,22 @@ begin
     SetError('ProjectFile nao configurado.');
     Exit(False);
   end;
+  ProjectPath := ExpandFileName(FProjectFile);
   FRunner.Executable := FLazBuildPath;
   FRunner.WorkingDirectory := FWorkingDirectory;
   if FRunner.WorkingDirectory = '' then
-    FRunner.WorkingDirectory := ExtractFileDir(ExpandFileName(FProjectFile));
+    FRunner.WorkingDirectory := ExtractFileDir(ProjectPath);
   FRunner.TimeoutMs := FTimeoutMs;
   if Trim(FBuildMode) <> '' then
   begin
     SetLength(Params, 2);
     Params[0] := '--build-mode=' + FBuildMode;
-    Params[1] := ExpandFileName(FProjectFile);
+    Params[1] := ProjectPath;
   end
   else
   begin
     SetLength(Params, 1);
-    Params[0] := ExpandFileName(FProjectFile);
+    Params[0] := ProjectPath;
   end;
   Result := FRunner.Execute(Params);
   FLastSuccess := Result;
@@ -366,12 +421,29 @@ begin
   FRunner.Stop;
 end;
 
+{ TAITestAgent }
+
 constructor TAITestAgent.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
   FCategory := ccAction;
   FTimeoutMs := 120000;
   FRunner := TAIProcessRunner.Create(Self);
+end;
+
+function TAITestAgent.GetStdOutText: string;
+begin
+  Result := FRunner.StdOutText;
+end;
+
+function TAITestAgent.GetStdErrText: string;
+begin
+  Result := FRunner.StdErrText;
+end;
+
+function TAITestAgent.GetExitCode: Integer;
+begin
+  Result := FRunner.LastExitCode;
 end;
 
 function TAITestAgent.SplitArguments(const S: string): TStringList;
@@ -390,12 +462,18 @@ begin
     begin
       if C = Quote then Quote := #0 else Token := Token + C;
     end
-    else if C in ['"', ''''] then Quote := C
+    else if (C = '"') or (C = #39) then
+      Quote := C
     else if C in [' ', #9] then
     begin
-      if Token <> '' then begin Result.Add(Token); Token := ''; end;
+      if Token <> '' then
+      begin
+        Result.Add(Token);
+        Token := '';
+      end;
     end
-    else Token := Token + C;
+    else
+      Token := Token + C;
   end;
   if Token <> '' then Result.Add(Token);
 end;
@@ -433,6 +511,8 @@ begin
   FRunner.Stop;
 end;
 
+{ TAINetworkAgent }
+
 constructor TAINetworkAgent.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
@@ -452,16 +532,16 @@ begin
     SetError('Host vazio.');
     Exit(False);
   end;
+  if ACount < 1 then ACount := 1;
   FRunner.Executable := 'ping';
   FRunner.TimeoutMs := FTimeoutMs;
-  SetLength(Params, 2);
+  SetLength(Params, 3);
   {$IFDEF WINDOWS}
   Params[0] := '-n';
   {$ELSE}
   Params[0] := '-c';
   {$ENDIF}
-  Params[1] := IntToStr(Max(1, ACount));
-  SetLength(Params, 3);
+  Params[1] := IntToStr(ACount);
   Params[2] := AHost;
   Result := FRunner.Execute(Params);
   FLastSuccess := Result;

--- a/pacote/AI Agent/aidevagents.pas
+++ b/pacote/AI Agent/aidevagents.pas
@@ -1,0 +1,499 @@
+unit aidevagents;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, StrUtils, fphttpclient, opensslsockets, LResources,
+  aibase, aiunifiedllm, aiprocessrunner;
+
+type
+  TAISourceAgent = class(TAIBaseComponent)
+  private
+    FLLM: TAIUnifiedLLM;
+    FRootDirectory: string;
+    FAllowWrite: Boolean;
+    FCreateBackup: Boolean;
+    FBackupExtension: string;
+    FLastBackupFile: string;
+    procedure SetLLM(AValue: TAIUnifiedLLM);
+    function ResolveFile(const AFileName: string; out AResolved: string): Boolean;
+    function ReadTextFile(const AFileName: string; out AText: string): Boolean;
+    function StripCodeFence(const AText: string): string;
+  protected
+    procedure Notification(AComponent: TComponent; Operation: TOperation); override;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function AnalyzeFile(const AFileName, AInstruction: string): Boolean;
+    function RewriteFile(const AFileName, AInstruction: string): Boolean;
+    function RestoreBackup(const AFileName: string): Boolean;
+    property LastBackupFile: string read FLastBackupFile;
+  published
+    property LLM: TAIUnifiedLLM read FLLM write SetLLM;
+    property RootDirectory: string read FRootDirectory write FRootDirectory;
+    property AllowWrite: Boolean read FAllowWrite write FAllowWrite default False;
+    property CreateBackup: Boolean read FCreateBackup write FCreateBackup default True;
+    property BackupExtension: string read FBackupExtension write FBackupExtension;
+  end;
+
+  TAILazarusBuildAgent = class(TAIBaseComponent)
+  private
+    FRunner: TAIProcessRunner;
+    FLazBuildPath: string;
+    FProjectFile: string;
+    FBuildMode: string;
+    FWorkingDirectory: string;
+    FTimeoutMs: Integer;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function Build: Boolean;
+    procedure Stop;
+    property StdOutText: string read FRunner.StdOutText;
+    property StdErrText: string read FRunner.StdErrText;
+    property ExitCode: Integer read FRunner.LastExitCode;
+  published
+    property LazBuildPath: string read FLazBuildPath write FLazBuildPath;
+    property ProjectFile: string read FProjectFile write FProjectFile;
+    property BuildMode: string read FBuildMode write FBuildMode;
+    property WorkingDirectory: string read FWorkingDirectory write FWorkingDirectory;
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 300000;
+  end;
+
+  TAITestAgent = class(TAIBaseComponent)
+  private
+    FRunner: TAIProcessRunner;
+    FExecutable: string;
+    FWorkingDirectory: string;
+    FArguments: string;
+    FTimeoutMs: Integer;
+    function SplitArguments(const S: string): TStringList;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function Run: Boolean;
+    procedure Stop;
+    property StdOutText: string read FRunner.StdOutText;
+    property StdErrText: string read FRunner.StdErrText;
+    property ExitCode: Integer read FRunner.LastExitCode;
+  published
+    property Executable: string read FExecutable write FExecutable;
+    property WorkingDirectory: string read FWorkingDirectory write FWorkingDirectory;
+    property Arguments: string read FArguments write FArguments;
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 120000;
+  end;
+
+  TAINetworkAgent = class(TAIBaseComponent)
+  private
+    FRunner: TAIProcessRunner;
+    FTimeoutMs: Integer;
+    FHTTPTimeoutMs: Integer;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function PingHost(const AHost: string; ACount: Integer = 1): Boolean;
+    function HTTPGet(const AURL: string): Boolean;
+    procedure Stop;
+  published
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 10000;
+    property HTTPTimeoutMs: Integer read FHTTPTimeoutMs write FHTTPTimeoutMs default 15000;
+  end;
+
+procedure Register;
+
+implementation
+
+procedure Register;
+begin
+  RegisterComponents('AI Agents', [TAISourceAgent, TAILazarusBuildAgent,
+    TAITestAgent, TAINetworkAgent]);
+end;
+
+function IsPathInsideRoot(const ARoot, AFileName: string): Boolean;
+var
+  RootPath, FilePath: string;
+begin
+  RootPath := IncludeTrailingPathDelimiter(ExpandFileName(ARoot));
+  FilePath := ExpandFileName(AFileName);
+  {$IFDEF WINDOWS}
+  Result := AnsiStartsText(RootPath, FilePath);
+  {$ELSE}
+  Result := AnsiStartsStr(RootPath, FilePath);
+  {$ENDIF}
+end;
+
+constructor TAISourceAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FRootDirectory := GetCurrentDir;
+  FAllowWrite := False;
+  FCreateBackup := True;
+  FBackupExtension := '.ai.bak';
+end;
+
+procedure TAISourceAgent.SetLLM(AValue: TAIUnifiedLLM);
+begin
+  if FLLM = AValue then Exit;
+  if Assigned(FLLM) then FLLM.RemoveFreeNotification(Self);
+  FLLM := AValue;
+  if Assigned(FLLM) then FLLM.FreeNotification(Self);
+end;
+
+procedure TAISourceAgent.Notification(AComponent: TComponent; Operation: TOperation);
+begin
+  inherited Notification(AComponent, Operation);
+  if (Operation = opRemove) and (AComponent = FLLM) then FLLM := nil;
+end;
+
+function TAISourceAgent.ResolveFile(const AFileName: string;
+  out AResolved: string): Boolean;
+begin
+  ClearError;
+  if Trim(FRootDirectory) = '' then
+  begin
+    SetError('RootDirectory nao configurado.');
+    Exit(False);
+  end;
+  if ExtractFilePath(AFileName) = '' then
+    AResolved := ExpandFileName(IncludeTrailingPathDelimiter(FRootDirectory) + AFileName)
+  else
+    AResolved := ExpandFileName(AFileName);
+  Result := IsPathInsideRoot(FRootDirectory, AResolved);
+  if not Result then SetError('Arquivo fora de RootDirectory: ' + AResolved);
+end;
+
+function TAISourceAgent.ReadTextFile(const AFileName: string;
+  out AText: string): Boolean;
+var
+  S: TStringList;
+begin
+  Result := False;
+  AText := '';
+  if not FileExists(AFileName) then
+  begin
+    SetError('Arquivo nao encontrado: ' + AFileName);
+    Exit;
+  end;
+  S := TStringList.Create;
+  try
+    try
+      S.LoadFromFile(AFileName);
+      AText := S.Text;
+      Result := True;
+    except
+      on E: Exception do SetError(E.Message);
+    end;
+  finally
+    S.Free;
+  end;
+end;
+
+function TAISourceAgent.StripCodeFence(const AText: string): string;
+var
+  S: string;
+  P: SizeInt;
+begin
+  S := Trim(AText);
+  if Pos('```', S) <> 1 then Exit(AText);
+  P := Pos(LineEnding, S);
+  if P > 0 then Delete(S, 1, P + Length(LineEnding) - 1);
+  if RightStr(TrimRight(S), 3) = '```' then
+  begin
+    S := TrimRight(S);
+    Delete(S, Length(S) - 2, 3);
+  end;
+  Result := S;
+end;
+
+function TAISourceAgent.AnalyzeFile(const AFileName, AInstruction: string): Boolean;
+var
+  FileName, Source, PromptText: string;
+begin
+  Result := False;
+  if FLLM = nil then
+  begin
+    SetError('LLM nao configurado.');
+    Exit;
+  end;
+  if not ResolveFile(AFileName, FileName) then Exit;
+  if not ReadTextFile(FileName, Source) then Exit;
+  PromptText := 'Analise o fonte Lazarus/Free Pascal abaixo conforme a orientacao. ' +
+    'Nao altere o arquivo. Responda com problemas, riscos e correcoes sugeridas.' +
+    LineEnding + 'ORIENTACAO:' + LineEnding + AInstruction + LineEnding +
+    'ARQUIVO: ' + FileName + LineEnding + 'FONTE:' + LineEnding + Source;
+  Result := FLLM.Ask(PromptText);
+  if Result then
+  begin
+    FLastResult := FLLM.LastResult;
+    FLastSuccess := True;
+  end
+  else
+    SetError(FLLM.LastError);
+end;
+
+function TAISourceAgent.RewriteFile(const AFileName, AInstruction: string): Boolean;
+var
+  FileName, Source, PromptText, NewSource, BackupName: string;
+  S: TStringList;
+begin
+  Result := False;
+  FLastBackupFile := '';
+  if not FAllowWrite then
+  begin
+    SetError('AllowWrite=False. Escrita bloqueada.');
+    Exit;
+  end;
+  if FLLM = nil then
+  begin
+    SetError('LLM nao configurado.');
+    Exit;
+  end;
+  if not ResolveFile(AFileName, FileName) then Exit;
+  if not ReadTextFile(FileName, Source) then Exit;
+  PromptText := 'Reescreva o arquivo Lazarus/Free Pascal conforme a orientacao. ' +
+    'Preserve compatibilidade e todo codigo nao relacionado. Retorne SOMENTE o fonte completo, sem markdown.' +
+    LineEnding + 'ORIENTACAO:' + LineEnding + AInstruction + LineEnding +
+    'ARQUIVO: ' + FileName + LineEnding + 'FONTE ATUAL:' + LineEnding + Source;
+  if not FLLM.Ask(PromptText) then
+  begin
+    SetError(FLLM.LastError);
+    Exit;
+  end;
+  NewSource := StripCodeFence(FLLM.LastResult);
+  if Trim(NewSource) = '' then
+  begin
+    SetError('LLM retornou fonte vazio.');
+    Exit;
+  end;
+
+  if FCreateBackup then
+  begin
+    BackupName := FileName + FBackupExtension;
+    if FileExists(BackupName) then DeleteFile(BackupName);
+    if not CopyFile(FileName, BackupName) then
+    begin
+      SetError('Nao foi possivel criar backup: ' + BackupName);
+      Exit;
+    end;
+    FLastBackupFile := BackupName;
+  end;
+
+  S := TStringList.Create;
+  try
+    try
+      S.Text := NewSource;
+      S.SaveToFile(FileName);
+      Result := True;
+      FLastSuccess := True;
+      FLastResult := FileName;
+    except
+      on E: Exception do SetError('Falha ao salvar fonte: ' + E.Message);
+    end;
+  finally
+    S.Free;
+  end;
+end;
+
+function TAISourceAgent.RestoreBackup(const AFileName: string): Boolean;
+var
+  FileName, BackupName: string;
+begin
+  Result := False;
+  if not FAllowWrite then
+  begin
+    SetError('AllowWrite=False. Escrita bloqueada.');
+    Exit;
+  end;
+  if not ResolveFile(AFileName, FileName) then Exit;
+  BackupName := FileName + FBackupExtension;
+  if not FileExists(BackupName) then
+  begin
+    SetError('Backup nao encontrado: ' + BackupName);
+    Exit;
+  end;
+  Result := CopyFile(BackupName, FileName);
+  if Result then
+  begin
+    FLastSuccess := True;
+    FLastResult := FileName;
+  end
+  else
+    SetError('Falha ao restaurar backup.');
+end;
+
+constructor TAILazarusBuildAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FLazBuildPath := 'lazbuild';
+  FTimeoutMs := 300000;
+  FRunner := TAIProcessRunner.Create(Self);
+end;
+
+function TAILazarusBuildAgent.Build: Boolean;
+var
+  Params: array of string;
+begin
+  ClearError;
+  if Trim(FProjectFile) = '' then
+  begin
+    SetError('ProjectFile nao configurado.');
+    Exit(False);
+  end;
+  FRunner.Executable := FLazBuildPath;
+  FRunner.WorkingDirectory := FWorkingDirectory;
+  if FRunner.WorkingDirectory = '' then
+    FRunner.WorkingDirectory := ExtractFileDir(ExpandFileName(FProjectFile));
+  FRunner.TimeoutMs := FTimeoutMs;
+  if Trim(FBuildMode) <> '' then
+  begin
+    SetLength(Params, 2);
+    Params[0] := '--build-mode=' + FBuildMode;
+    Params[1] := ExpandFileName(FProjectFile);
+  end
+  else
+  begin
+    SetLength(Params, 1);
+    Params[0] := ExpandFileName(FProjectFile);
+  end;
+  Result := FRunner.Execute(Params);
+  FLastSuccess := Result;
+  FLastResult := FRunner.StdOutText;
+  if not Result then SetError(FRunner.LastError);
+end;
+
+procedure TAILazarusBuildAgent.Stop;
+begin
+  FRunner.Stop;
+end;
+
+constructor TAITestAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FTimeoutMs := 120000;
+  FRunner := TAIProcessRunner.Create(Self);
+end;
+
+function TAITestAgent.SplitArguments(const S: string): TStringList;
+var
+  I: Integer;
+  C, Quote: Char;
+  Token: string;
+begin
+  Result := TStringList.Create;
+  Token := '';
+  Quote := #0;
+  for I := 1 to Length(S) do
+  begin
+    C := S[I];
+    if Quote <> #0 then
+    begin
+      if C = Quote then Quote := #0 else Token := Token + C;
+    end
+    else if C in ['"', ''''] then Quote := C
+    else if C in [' ', #9] then
+    begin
+      if Token <> '' then begin Result.Add(Token); Token := ''; end;
+    end
+    else Token := Token + C;
+  end;
+  if Token <> '' then Result.Add(Token);
+end;
+
+function TAITestAgent.Run: Boolean;
+var
+  Args: TStringList;
+  Params: array of string;
+  I: Integer;
+begin
+  ClearError;
+  if Trim(FExecutable) = '' then
+  begin
+    SetError('Executable nao configurado.');
+    Exit(False);
+  end;
+  FRunner.Executable := FExecutable;
+  FRunner.WorkingDirectory := FWorkingDirectory;
+  FRunner.TimeoutMs := FTimeoutMs;
+  Args := SplitArguments(FArguments);
+  try
+    SetLength(Params, Args.Count);
+    for I := 0 to Args.Count - 1 do Params[I] := Args[I];
+    Result := FRunner.Execute(Params);
+  finally
+    Args.Free;
+  end;
+  FLastSuccess := Result;
+  FLastResult := FRunner.StdOutText;
+  if not Result then SetError(FRunner.LastError);
+end;
+
+procedure TAITestAgent.Stop;
+begin
+  FRunner.Stop;
+end;
+
+constructor TAINetworkAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FTimeoutMs := 10000;
+  FHTTPTimeoutMs := 15000;
+  FRunner := TAIProcessRunner.Create(Self);
+end;
+
+function TAINetworkAgent.PingHost(const AHost: string; ACount: Integer): Boolean;
+var
+  Params: array of string;
+begin
+  ClearError;
+  if Trim(AHost) = '' then
+  begin
+    SetError('Host vazio.');
+    Exit(False);
+  end;
+  FRunner.Executable := 'ping';
+  FRunner.TimeoutMs := FTimeoutMs;
+  SetLength(Params, 2);
+  {$IFDEF WINDOWS}
+  Params[0] := '-n';
+  {$ELSE}
+  Params[0] := '-c';
+  {$ENDIF}
+  Params[1] := IntToStr(Max(1, ACount));
+  SetLength(Params, 3);
+  Params[2] := AHost;
+  Result := FRunner.Execute(Params);
+  FLastSuccess := Result;
+  FLastResult := FRunner.StdOutText;
+  if not Result then SetError(FRunner.LastError);
+end;
+
+function TAINetworkAgent.HTTPGet(const AURL: string): Boolean;
+var
+  HTTP: TFPHttpClient;
+begin
+  ClearError;
+  Result := False;
+  HTTP := TFPHttpClient.Create(nil);
+  try
+    HTTP.ConnectTimeout := FHTTPTimeoutMs;
+    HTTP.IOTimeout := FHTTPTimeoutMs;
+    try
+      FLastResult := HTTP.Get(AURL);
+      Result := True;
+      FLastSuccess := True;
+    except
+      on E: Exception do SetError(E.Message);
+    end;
+  finally
+    HTTP.Free;
+  end;
+end;
+
+procedure TAINetworkAgent.Stop;
+begin
+  FRunner.Stop;
+end;
+
+end.

--- a/pacote/AI Agent/aiserviceagents.pas
+++ b/pacote/AI Agent/aiserviceagents.pas
@@ -1,0 +1,387 @@
+unit aiserviceagents;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fphttpclient, opensslsockets, LResources, aibase;
+
+type
+  TAIServiceAgent = class(TAIBaseComponent)
+  private
+    FAccessToken: string;
+    FAllowWrite: Boolean;
+    FTimeoutMs: Integer;
+    FLastHTTPStatus: Integer;
+  protected
+    function URLencode(const S: string): string;
+    function DoRequest(const AMethod, AURL, ABody, AContentType: string;
+      const AHeaders: array of string): Boolean;
+    function RequireWrite: Boolean;
+    property AccessTokenValue: string read FAccessToken;
+  public
+    constructor Create(AOwner: TComponent); override;
+    property LastHTTPStatus: Integer read FLastHTTPStatus;
+  published
+    property AccessToken: string read FAccessToken write FAccessToken;
+    property AllowWrite: Boolean read FAllowWrite write FAllowWrite default False;
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 30000;
+  end;
+
+  TAIGitHubAgent = class(TAIServiceAgent)
+  private
+    FOwner: string;
+    FRepository: string;
+    FBaseURL: string;
+    FAPIVersion: string;
+    function RepoURL(const ASuffix: string): string;
+    function GitHubHeaders: TStringList;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function GetRepository: Boolean;
+    function ListIssues(const AState: string = 'open'): Boolean;
+    function GetIssue(AIssueNumber: Integer): Boolean;
+    function CreateIssue(const ATitle, ABody: string): Boolean;
+    function AddIssueComment(AIssueNumber: Integer; const ABody: string): Boolean;
+  published
+    property Owner: string read FOwner write FOwner;
+    property Repository: string read FRepository write FRepository;
+    property BaseURL: string read FBaseURL write FBaseURL;
+    property APIVersion: string read FAPIVersion write FAPIVersion;
+  end;
+
+  TAIFacebookAgent = class(TAIServiceAgent)
+  private
+    FPageID: string;
+    FBaseURL: string;
+    FAPIVersion: string;
+    function GraphURL(const APath: string): string;
+    function WithToken(const AURL: string): string;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function GetPage(const AFields: string = 'id,name'): Boolean;
+    function GetFeed(ALimit: Integer = 25): Boolean;
+    function PublishPost(const AMessage: string): Boolean;
+  published
+    property PageID: string read FPageID write FPageID;
+    property BaseURL: string read FBaseURL write FBaseURL;
+    property APIVersion: string read FAPIVersion write FAPIVersion;
+  end;
+
+  TAIYouTubeAgent = class(TAIServiceAgent)
+  private
+    FAPIKey: string;
+    FChannelID: string;
+    FBaseURL: string;
+    function YouTubeURL(const APath: string): string;
+    function WithAPIKey(const AURL: string): string;
+    function OAuthHeaders: TStringList;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function GetChannel: Boolean;
+    function GetMyChannel: Boolean;
+    function Search(const AQuery: string; AMaxResults: Integer = 10): Boolean;
+    function GetVideo(const AVideoID: string): Boolean;
+    function ListComments(const AVideoID: string; AMaxResults: Integer = 20): Boolean;
+    function CreateComment(const AVideoID, AText: string): Boolean;
+  published
+    property APIKey: string read FAPIKey write FAPIKey;
+    property ChannelID: string read FChannelID write FChannelID;
+    property BaseURL: string read FBaseURL write FBaseURL;
+  end;
+
+procedure Register;
+
+implementation
+
+procedure Register;
+begin
+  RegisterComponents('AI Agents', [TAIGitHubAgent, TAIFacebookAgent, TAIYouTubeAgent]);
+end;
+
+{ TAIServiceAgent }
+
+constructor TAIServiceAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FAllowWrite := False;
+  FTimeoutMs := 30000;
+  FLastHTTPStatus := 0;
+end;
+
+function TAIServiceAgent.URLencode(const S: string): string;
+var
+  I: Integer;
+  B: Byte;
+  U: UTF8String;
+begin
+  Result := '';
+  U := UTF8Encode(S);
+  for I := 1 to Length(U) do
+  begin
+    B := Ord(U[I]);
+    if ((B >= Ord('A')) and (B <= Ord('Z'))) or
+       ((B >= Ord('a')) and (B <= Ord('z'))) or
+       ((B >= Ord('0')) and (B <= Ord('9'))) or
+       (B = Ord('-')) or (B = Ord('_')) or (B = Ord('.')) or (B = Ord('~')) then
+      Result := Result + Chr(B)
+    else
+      Result := Result + '%' + IntToHex(B, 2);
+  end;
+end;
+
+function TAIServiceAgent.DoRequest(const AMethod, AURL, ABody, AContentType: string;
+  const AHeaders: array of string): Boolean;
+var
+  Client: TFPHTTPClient;
+  ResponseStream, BodyStream: TStringStream;
+  I, P: Integer;
+  HName, HValue: string;
+begin
+  Result := False;
+  ClearError;
+  FLastHTTPStatus := 0;
+  ResponseStream := TStringStream.Create('');
+  BodyStream := nil;
+  Client := TFPHTTPClient.Create(nil);
+  try
+    Client.AllowRedirect := True;
+    Client.ConnectTimeout := FTimeoutMs;
+    Client.IOTimeout := FTimeoutMs;
+    for I := Low(AHeaders) to High(AHeaders) do
+    begin
+      P := Pos(':', AHeaders[I]);
+      if P > 0 then
+      begin
+        HName := Trim(Copy(AHeaders[I], 1, P - 1));
+        HValue := Trim(Copy(AHeaders[I], P + 1, MaxInt));
+        if HName <> '' then Client.AddHeader(HName, HValue);
+      end;
+    end;
+    if AContentType <> '' then Client.AddHeader('Content-Type', AContentType);
+    if ABody <> '' then
+    begin
+      BodyStream := TStringStream.Create(ABody);
+      Client.RequestBody := BodyStream;
+    end;
+    try
+      Client.HTTPMethod(UpperCase(AMethod), AURL, ResponseStream, [200, 201, 202, 204]);
+      FLastHTTPStatus := Client.ResponseStatusCode;
+      FLastResult := ResponseStream.DataString;
+      FLastSuccess := True;
+      Result := True;
+    except
+      on E: Exception do
+      begin
+        FLastHTTPStatus := Client.ResponseStatusCode;
+        FLastResult := ResponseStream.DataString;
+        SetError(E.Message);
+      end;
+    end;
+  finally
+    Client.RequestBody := nil;
+    BodyStream.Free;
+    Client.Free;
+    ResponseStream.Free;
+  end;
+end;
+
+function TAIServiceAgent.RequireWrite: Boolean;
+begin
+  Result := FAllowWrite;
+  if not Result then SetError('AllowWrite=False. Operacao de escrita bloqueada.');
+end;
+
+{ TAIGitHubAgent }
+
+constructor TAIGitHubAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FBaseURL := 'https://api.github.com';
+  FAPIVersion := '2026-03-10';
+end;
+
+function TAIGitHubAgent.RepoURL(const ASuffix: string): string;
+begin
+  Result := ExcludeTrailingPathDelimiter(FBaseURL) + '/repos/' + URLencode(FOwner) + '/' +
+    URLencode(FRepository) + ASuffix;
+end;
+
+function TAIGitHubAgent.GitHubHeaders: TStringList;
+begin
+  Result := TStringList.Create;
+  Result.Add('Accept: application/vnd.github+json');
+  Result.Add('X-GitHub-Api-Version: ' + FAPIVersion);
+  Result.Add('User-Agent: CHATGPT-Lazarus-Agent');
+  if Trim(AccessTokenValue) <> '' then
+    Result.Add('Authorization: Bearer ' + AccessTokenValue);
+end;
+
+function TAIGitHubAgent.GetRepository: Boolean;
+var H: TStringList;
+begin
+  H := GitHubHeaders;
+  try Result := DoRequest('GET', RepoURL(''), '', '', H.ToStringArray); finally H.Free; end;
+end;
+
+function TAIGitHubAgent.ListIssues(const AState: string): Boolean;
+var H: TStringList;
+begin
+  H := GitHubHeaders;
+  try Result := DoRequest('GET', RepoURL('/issues?state=' + URLencode(AState)), '', '', H.ToStringArray); finally H.Free; end;
+end;
+
+function TAIGitHubAgent.GetIssue(AIssueNumber: Integer): Boolean;
+var H: TStringList;
+begin
+  H := GitHubHeaders;
+  try Result := DoRequest('GET', RepoURL('/issues/' + IntToStr(AIssueNumber)), '', '', H.ToStringArray); finally H.Free; end;
+end;
+
+function TAIGitHubAgent.CreateIssue(const ATitle, ABody: string): Boolean;
+var H: TStringList; Body: string;
+begin
+  if not RequireWrite then Exit(False);
+  Body := '{"title":"' + StringReplace(StringReplace(ATitle, '\', '\\', [rfReplaceAll]), '"', '\"', [rfReplaceAll]) +
+    '","body":"' + StringReplace(StringReplace(StringReplace(ABody, '\', '\\', [rfReplaceAll]), '"', '\"', [rfReplaceAll]), LineEnding, '\n', [rfReplaceAll]) + '"}';
+  H := GitHubHeaders;
+  try Result := DoRequest('POST', RepoURL('/issues'), Body, 'application/json; charset=utf-8', H.ToStringArray); finally H.Free; end;
+end;
+
+function TAIGitHubAgent.AddIssueComment(AIssueNumber: Integer; const ABody: string): Boolean;
+var H: TStringList; Body: string;
+begin
+  if not RequireWrite then Exit(False);
+  Body := '{"body":"' + StringReplace(StringReplace(StringReplace(ABody, '\', '\\', [rfReplaceAll]), '"', '\"', [rfReplaceAll]), LineEnding, '\n', [rfReplaceAll]) + '"}';
+  H := GitHubHeaders;
+  try Result := DoRequest('POST', RepoURL('/issues/' + IntToStr(AIssueNumber) + '/comments'), Body,
+    'application/json; charset=utf-8', H.ToStringArray); finally H.Free; end;
+end;
+
+{ TAIFacebookAgent }
+
+constructor TAIFacebookAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FBaseURL := 'https://graph.facebook.com';
+  FAPIVersion := '';
+end;
+
+function TAIFacebookAgent.GraphURL(const APath: string): string;
+begin
+  Result := ExcludeTrailingPathDelimiter(FBaseURL);
+  if Trim(FAPIVersion) <> '' then Result := Result + '/' + Trim(FAPIVersion);
+  if (APath <> '') and (APath[1] <> '/') then Result := Result + '/';
+  Result := Result + APath;
+end;
+
+function TAIFacebookAgent.WithToken(const AURL: string): string;
+begin
+  Result := AURL;
+  if Trim(AccessTokenValue) = '' then Exit;
+  if Pos('?', Result) > 0 then Result := Result + '&' else Result := Result + '?';
+  Result := Result + 'access_token=' + URLencode(AccessTokenValue);
+end;
+
+function TAIFacebookAgent.GetPage(const AFields: string): Boolean;
+begin
+  Result := DoRequest('GET', WithToken(GraphURL(FPageID + '?fields=' + URLencode(AFields))), '', '', []);
+end;
+
+function TAIFacebookAgent.GetFeed(ALimit: Integer): Boolean;
+begin
+  if ALimit < 1 then ALimit := 1;
+  if ALimit > 100 then ALimit := 100;
+  Result := DoRequest('GET', WithToken(GraphURL(FPageID + '/feed?limit=' + IntToStr(ALimit))), '', '', []);
+end;
+
+function TAIFacebookAgent.PublishPost(const AMessage: string): Boolean;
+var Body: string;
+begin
+  if not RequireWrite then Exit(False);
+  Body := 'message=' + URLencode(AMessage) + '&access_token=' + URLencode(AccessTokenValue);
+  Result := DoRequest('POST', GraphURL(FPageID + '/feed'), Body,
+    'application/x-www-form-urlencoded; charset=utf-8', []);
+end;
+
+{ TAIYouTubeAgent }
+
+constructor TAIYouTubeAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FBaseURL := 'https://www.googleapis.com/youtube/v3';
+end;
+
+function TAIYouTubeAgent.YouTubeURL(const APath: string): string;
+begin
+  Result := ExcludeTrailingPathDelimiter(FBaseURL);
+  if (APath <> '') and (APath[1] <> '/') then Result := Result + '/';
+  Result := Result + APath;
+end;
+
+function TAIYouTubeAgent.WithAPIKey(const AURL: string): string;
+begin
+  Result := AURL;
+  if Trim(FAPIKey) = '' then Exit;
+  if Pos('?', Result) > 0 then Result := Result + '&' else Result := Result + '?';
+  Result := Result + 'key=' + URLencode(FAPIKey);
+end;
+
+function TAIYouTubeAgent.OAuthHeaders: TStringList;
+begin
+  Result := TStringList.Create;
+  if Trim(AccessTokenValue) <> '' then Result.Add('Authorization: Bearer ' + AccessTokenValue);
+  Result.Add('Accept: application/json');
+end;
+
+function TAIYouTubeAgent.GetChannel: Boolean;
+begin
+  Result := DoRequest('GET', WithAPIKey(YouTubeURL('channels?part=snippet,statistics,contentDetails&id=' +
+    URLencode(FChannelID))), '', '', []);
+end;
+
+function TAIYouTubeAgent.GetMyChannel: Boolean;
+var H: TStringList;
+begin
+  H := OAuthHeaders;
+  try Result := DoRequest('GET', YouTubeURL('channels?part=snippet,statistics,contentDetails&mine=true'), '', '', H.ToStringArray); finally H.Free; end;
+end;
+
+function TAIYouTubeAgent.Search(const AQuery: string; AMaxResults: Integer): Boolean;
+begin
+  if AMaxResults < 1 then AMaxResults := 1;
+  if AMaxResults > 50 then AMaxResults := 50;
+  Result := DoRequest('GET', WithAPIKey(YouTubeURL('search?part=snippet&type=video&maxResults=' +
+    IntToStr(AMaxResults) + '&q=' + URLencode(AQuery))), '', '', []);
+end;
+
+function TAIYouTubeAgent.GetVideo(const AVideoID: string): Boolean;
+begin
+  Result := DoRequest('GET', WithAPIKey(YouTubeURL('videos?part=snippet,statistics,contentDetails&id=' +
+    URLencode(AVideoID))), '', '', []);
+end;
+
+function TAIYouTubeAgent.ListComments(const AVideoID: string; AMaxResults: Integer): Boolean;
+begin
+  if AMaxResults < 1 then AMaxResults := 1;
+  if AMaxResults > 100 then AMaxResults := 100;
+  Result := DoRequest('GET', WithAPIKey(YouTubeURL('commentThreads?part=snippet&videoId=' +
+    URLencode(AVideoID) + '&maxResults=' + IntToStr(AMaxResults))), '', '', []);
+end;
+
+function TAIYouTubeAgent.CreateComment(const AVideoID, AText: string): Boolean;
+var
+  H: TStringList;
+  Body, SafeText: string;
+begin
+  if not RequireWrite then Exit(False);
+  SafeText := StringReplace(StringReplace(StringReplace(AText, '\', '\\', [rfReplaceAll]), '"', '\"', [rfReplaceAll]), LineEnding, '\n', [rfReplaceAll]);
+  Body := '{"snippet":{"videoId":"' + URLencode(AVideoID) + '","topLevelComment":{"snippet":{"textOriginal":"' + SafeText + '"}}}}';
+  H := OAuthHeaders;
+  try Result := DoRequest('POST', YouTubeURL('commentThreads?part=snippet'), Body,
+    'application/json; charset=utf-8', H.ToStringArray); finally H.Free; end;
+end;
+
+end.

--- a/pacote/AI/aicapabilities.pas
+++ b/pacote/AI/aicapabilities.pas
@@ -1,0 +1,215 @@
+unit aicapabilities;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, aillmproviders;
+
+type
+  TAICapability = (
+    aicChat,
+    aicStreaming,
+    aicTools,
+    aicJSON,
+    aicVision,
+    aicEmbeddings,
+    aicSTT,
+    aicTTS,
+    aicVideo,
+    aicTraining,
+    aicLocal,
+    aicTemperature
+  );
+  TAICapabilities = set of TAICapability;
+
+  { TAICapabilityRegistry }
+
+  TAICapabilityRegistry = class(TComponent)
+  private
+    FOverrides: TStringList;
+    function ProviderKey(AKind: TAILLMProviderKind): string;
+  public
+    constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+    function DefaultCapabilities(AKind: TAILLMProviderKind): TAICapabilities;
+    function CapabilitiesOf(AKind: TAILLMProviderKind): TAICapabilities;
+    function Supports(AKind: TAILLMProviderKind; ACapability: TAICapability): Boolean;
+    procedure SetCapabilities(AKind: TAILLMProviderKind; const ACapabilities: TAICapabilities);
+    procedure ClearOverride(AKind: TAILLMProviderKind);
+    function CapabilitiesAsText(AKind: TAILLMProviderKind): string;
+  end;
+
+function AICapabilityName(ACapability: TAICapability): string;
+
+implementation
+
+function AICapabilityName(ACapability: TAICapability): string;
+begin
+  case ACapability of
+    aicChat: Result := 'chat';
+    aicStreaming: Result := 'streaming';
+    aicTools: Result := 'tools';
+    aicJSON: Result := 'json';
+    aicVision: Result := 'vision';
+    aicEmbeddings: Result := 'embeddings';
+    aicSTT: Result := 'stt';
+    aicTTS: Result := 'tts';
+    aicVideo: Result := 'video';
+    aicTraining: Result := 'training';
+    aicLocal: Result := 'local';
+    aicTemperature: Result := 'temperature';
+  else
+    Result := 'unknown';
+  end;
+end;
+
+constructor TAICapabilityRegistry.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FOverrides := TStringList.Create;
+  FOverrides.CaseSensitive := False;
+  FOverrides.NameValueSeparator := '=';
+end;
+
+destructor TAICapabilityRegistry.Destroy;
+begin
+  FOverrides.Free;
+  inherited Destroy;
+end;
+
+function TAICapabilityRegistry.ProviderKey(AKind: TAILLMProviderKind): string;
+begin
+  Result := IntToStr(Ord(AKind));
+end;
+
+function TAICapabilityRegistry.DefaultCapabilities(
+  AKind: TAILLMProviderKind): TAICapabilities;
+begin
+  Result := [aicChat, aicJSON];
+
+  case AKind of
+    llmOpenAI,
+    llmOpenAICompatible,
+    llmLlamaCpp,
+    llmNeuralAPI,
+    llmDeepSeek,
+    llmOpenRouter,
+    llmCerebras,
+    llmOllama:
+      Include(Result, aicStreaming);
+  end;
+
+  case AKind of
+    llmOpenAI,
+    llmOpenAICompatible,
+    llmGemini,
+    llmClaude,
+    llmDeepSeek,
+    llmOpenRouter:
+      Include(Result, aicTools);
+  end;
+
+  case AKind of
+    llmOpenAI,
+    llmGemini,
+    llmClaude,
+    llmOpenRouter:
+      Include(Result, aicVision);
+  end;
+
+  case AKind of
+    llmOpenAI,
+    llmOpenAICompatible,
+    llmLlamaCpp,
+    llmNeuralAPI,
+    llmOllama,
+    llmOpenRouter:
+      Include(Result, aicEmbeddings);
+  end;
+
+  case AKind of
+    llmLlamaCpp,
+    llmNeuralAPI,
+    llmOllama:
+      Include(Result, aicLocal);
+  end;
+
+  if AKind <> llmGemini then
+    Include(Result, aicTemperature);
+end;
+
+function TAICapabilityRegistry.CapabilitiesOf(
+  AKind: TAILLMProviderKind): TAICapabilities;
+var
+  S: string;
+  I, N: Integer;
+  C: TAICapability;
+begin
+  Result := DefaultCapabilities(AKind);
+  S := FOverrides.Values[ProviderKey(AKind)];
+  if S = '' then
+    Exit;
+
+  Result := [];
+  for I := 1 to Length(S) do
+    if S[I] = '1' then
+    begin
+      N := I - 1;
+      if N <= Ord(High(TAICapability)) then
+      begin
+        C := TAICapability(N);
+        Include(Result, C);
+      end;
+    end;
+end;
+
+function TAICapabilityRegistry.Supports(AKind: TAILLMProviderKind;
+  ACapability: TAICapability): Boolean;
+begin
+  Result := ACapability in CapabilitiesOf(AKind);
+end;
+
+procedure TAICapabilityRegistry.SetCapabilities(AKind: TAILLMProviderKind;
+  const ACapabilities: TAICapabilities);
+var
+  C: TAICapability;
+  S: string;
+begin
+  S := '';
+  for C := Low(TAICapability) to High(TAICapability) do
+    if C in ACapabilities then
+      S := S + '1'
+    else
+      S := S + '0';
+  FOverrides.Values[ProviderKey(AKind)] := S;
+end;
+
+procedure TAICapabilityRegistry.ClearOverride(AKind: TAILLMProviderKind);
+var
+  I: Integer;
+begin
+  I := FOverrides.IndexOfName(ProviderKey(AKind));
+  if I >= 0 then
+    FOverrides.Delete(I);
+end;
+
+function TAICapabilityRegistry.CapabilitiesAsText(
+  AKind: TAILLMProviderKind): string;
+var
+  C: TAICapability;
+  Caps: TAICapabilities;
+begin
+  Result := '';
+  Caps := CapabilitiesOf(AKind);
+  for C := Low(TAICapability) to High(TAICapability) do
+    if C in Caps then
+    begin
+      if Result <> '' then
+        Result := Result + ',';
+      Result := Result + AICapabilityName(C);
+    end;
+end;
+
+end.

--- a/pacote/AI/aimodelrouter.pas
+++ b/pacote/AI/aimodelrouter.pas
@@ -1,0 +1,185 @@
+unit aimodelrouter;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, Contnrs, aibase, aillmproviders, aicapabilities;
+
+type
+  TAIModelRoute = class
+  private
+    FProviderKind: TAILLMProviderKind;
+    FModel: string;
+    FEndpoint: string;
+    FToken: string;
+    FEnabled: Boolean;
+    FPriority: Integer;
+    FLocal: Boolean;
+  public
+    constructor Create;
+  published
+    property ProviderKind: TAILLMProviderKind read FProviderKind write FProviderKind;
+    property Model: string read FModel write FModel;
+    property Endpoint: string read FEndpoint write FEndpoint;
+    property Token: string read FToken write FToken;
+    property Enabled: Boolean read FEnabled write FEnabled default True;
+    property Priority: Integer read FPriority write FPriority default 100;
+    property Local: Boolean read FLocal write FLocal;
+  end;
+
+  { TAIModelRouter }
+
+  TAIModelRouter = class(TAIBaseComponent)
+  private
+    FRoutes: TObjectList;
+    FCapabilities: TAICapabilityRegistry;
+    FPreferLocal: Boolean;
+    function GetRouteCount: Integer;
+    function GetRoute(AIndex: Integer): TAIModelRoute;
+    function RouteSupports(ARoute: TAIModelRoute;
+      const ARequired: TAICapabilities): Boolean;
+    function ScoreRoute(ARoute: TAIModelRoute): Integer;
+  public
+    constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+    procedure Clear;
+    function AddRoute(AProvider: TAILLMProviderKind; const AModel: string;
+      const AEndpoint: string = ''; const AToken: string = '';
+      APriority: Integer = 100): TAIModelRoute;
+    function Select(const ARequired: TAICapabilities): TAIModelRoute;
+    function SelectProvider(const ARequired: TAICapabilities;
+      out AProvider: TAILLMProviderKind; out AModel, AEndpoint, AToken: string): Boolean;
+    property RouteCount: Integer read GetRouteCount;
+    property Routes[AIndex: Integer]: TAIModelRoute read GetRoute;
+    property CapabilityRegistry: TAICapabilityRegistry read FCapabilities;
+  published
+    property PreferLocal: Boolean read FPreferLocal write FPreferLocal default True;
+  end;
+
+procedure Register;
+
+implementation
+
+procedure Register;
+begin
+  RegisterComponents('AI Core', [TAIModelRouter]);
+end;
+
+constructor TAIModelRoute.Create;
+begin
+  inherited Create;
+  FProviderKind := llmOpenAICompatible;
+  FEnabled := True;
+  FPriority := 100;
+  FLocal := False;
+end;
+
+constructor TAIModelRouter.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccModel;
+  FRoutes := TObjectList.Create(True);
+  FCapabilities := TAICapabilityRegistry.Create(Self);
+  FPreferLocal := True;
+end;
+
+destructor TAIModelRouter.Destroy;
+begin
+  FRoutes.Free;
+  inherited Destroy;
+end;
+
+procedure TAIModelRouter.Clear;
+begin
+  FRoutes.Clear;
+  ClearError;
+end;
+
+function TAIModelRouter.GetRouteCount: Integer;
+begin
+  Result := FRoutes.Count;
+end;
+
+function TAIModelRouter.GetRoute(AIndex: Integer): TAIModelRoute;
+begin
+  Result := TAIModelRoute(FRoutes[AIndex]);
+end;
+
+function TAIModelRouter.AddRoute(AProvider: TAILLMProviderKind;
+  const AModel, AEndpoint, AToken: string; APriority: Integer): TAIModelRoute;
+begin
+  Result := TAIModelRoute.Create;
+  Result.ProviderKind := AProvider;
+  Result.Model := AModel;
+  Result.Endpoint := AEndpoint;
+  Result.Token := AToken;
+  Result.Priority := APriority;
+  Result.Local := FCapabilities.Supports(AProvider, aicLocal);
+  FRoutes.Add(Result);
+end;
+
+function TAIModelRouter.RouteSupports(ARoute: TAIModelRoute;
+  const ARequired: TAICapabilities): Boolean;
+var
+  C: TAICapability;
+begin
+  Result := Assigned(ARoute) and ARoute.Enabled;
+  if not Result then Exit;
+  for C := Low(TAICapability) to High(TAICapability) do
+    if (C in ARequired) and
+       (not FCapabilities.Supports(ARoute.ProviderKind, C)) then
+      Exit(False);
+end;
+
+function TAIModelRouter.ScoreRoute(ARoute: TAIModelRoute): Integer;
+begin
+  Result := ARoute.Priority;
+  if FPreferLocal and ARoute.Local then
+    Dec(Result, 100000);
+end;
+
+function TAIModelRouter.Select(const ARequired: TAICapabilities): TAIModelRoute;
+var
+  I, BestScore, S: Integer;
+  R: TAIModelRoute;
+begin
+  Result := nil;
+  BestScore := MaxInt;
+  for I := 0 to FRoutes.Count - 1 do
+  begin
+    R := GetRoute(I);
+    if not RouteSupports(R, ARequired) then Continue;
+    S := ScoreRoute(R);
+    if (Result = nil) or (S < BestScore) then
+    begin
+      Result := R;
+      BestScore := S;
+    end;
+  end;
+
+  if Result = nil then
+    SetError('Nenhuma rota LLM atende as capacidades solicitadas.')
+  else
+  begin
+    ClearError;
+    FLastResult := AILLMProviderKindName(Result.ProviderKind) + ':' + Result.Model;
+  end;
+end;
+
+function TAIModelRouter.SelectProvider(const ARequired: TAICapabilities;
+  out AProvider: TAILLMProviderKind; out AModel, AEndpoint, AToken: string): Boolean;
+var
+  R: TAIModelRoute;
+begin
+  R := Select(ARequired);
+  Result := Assigned(R);
+  if not Result then Exit;
+  AProvider := R.ProviderKind;
+  AModel := R.Model;
+  AEndpoint := R.Endpoint;
+  AToken := R.Token;
+end;
+
+end.

--- a/pacote/AI/aimodelrouter.pas
+++ b/pacote/AI/aimodelrouter.pas
@@ -5,7 +5,8 @@ unit aimodelrouter;
 interface
 
 uses
-  Classes, SysUtils, Contnrs, aibase, aillmproviders, aicapabilities;
+  Classes, SysUtils, Contnrs, LResources, aibase, aillmproviders,
+  aicapabilities;
 
 type
   TAIModelRoute = class
@@ -29,8 +30,6 @@ type
     property Local: Boolean read FLocal write FLocal;
   end;
 
-  { TAIModelRouter }
-
   TAIModelRouter = class(TAIBaseComponent)
   private
     FRoutes: TObjectList;
@@ -50,7 +49,8 @@ type
       APriority: Integer = 100): TAIModelRoute;
     function Select(const ARequired: TAICapabilities): TAIModelRoute;
     function SelectProvider(const ARequired: TAICapabilities;
-      out AProvider: TAILLMProviderKind; out AModel, AEndpoint, AToken: string): Boolean;
+      out AProvider: TAILLMProviderKind; out AModel, AEndpoint,
+      AToken: string): Boolean;
     property RouteCount: Integer read GetRouteCount;
     property Routes[AIndex: Integer]: TAIModelRoute read GetRoute;
     property CapabilityRegistry: TAICapabilityRegistry read FCapabilities;
@@ -126,7 +126,8 @@ var
   C: TAICapability;
 begin
   Result := Assigned(ARoute) and ARoute.Enabled;
-  if not Result then Exit;
+  if not Result then
+    Exit;
   for C := Low(TAICapability) to High(TAICapability) do
     if (C in ARequired) and
        (not FCapabilities.Supports(ARoute.ProviderKind, C)) then
@@ -150,7 +151,8 @@ begin
   for I := 0 to FRoutes.Count - 1 do
   begin
     R := GetRoute(I);
-    if not RouteSupports(R, ARequired) then Continue;
+    if not RouteSupports(R, ARequired) then
+      Continue;
     S := ScoreRoute(R);
     if (Result = nil) or (S < BestScore) then
     begin
@@ -175,7 +177,8 @@ var
 begin
   R := Select(ARequired);
   Result := Assigned(R);
-  if not Result then Exit;
+  if not Result then
+    Exit;
   AProvider := R.ProviderKind;
   AModel := R.Model;
   AEndpoint := R.Endpoint;

--- a/pacote/AI/aiunifiedllm.pas
+++ b/pacote/AI/aiunifiedllm.pas
@@ -5,11 +5,10 @@ unit aiunifiedllm;
 interface
 
 uses
-  Classes, SysUtils, aibase, aillmproviders, aicapabilities, aimodelrouter;
+  Classes, SysUtils, LResources, aibase, aillmproviders, aicapabilities,
+  aimodelrouter;
 
 type
-  { TAIUnifiedLLM }
-
   TAIUnifiedLLM = class(TAIBaseComponent)
   private
     FProviderKind: TAILLMProviderKind;
@@ -28,6 +27,7 @@ type
     FOnStreamData: TAILLMStreamDataEvent;
     FProvider: IAILLMProvider;
     procedure ApplyRouter;
+    procedure SetRouter(AValue: TAIModelRouter);
   protected
     procedure Notification(AComponent: TComponent; Operation: TOperation); override;
   public
@@ -50,7 +50,7 @@ type
     property Stream: Boolean read FStream write FStream default False;
     property AutoRoute: Boolean read FAutoRoute write FAutoRoute default False;
     property PreferLocal: Boolean read FPreferLocal write FPreferLocal default True;
-    property Router: TAIModelRouter read FRouter write FRouter;
+    property Router: TAIModelRouter read FRouter write SetRouter;
     property OnStreamData: TAILLMStreamDataEvent read FOnStreamData write FOnStreamData;
   end;
 
@@ -77,6 +77,17 @@ begin
   FRequiredCapabilities := [aicChat];
 end;
 
+procedure TAIUnifiedLLM.SetRouter(AValue: TAIModelRouter);
+begin
+  if FRouter = AValue then
+    Exit;
+  if Assigned(FRouter) then
+    FRouter.RemoveFreeNotification(Self);
+  FRouter := AValue;
+  if Assigned(FRouter) then
+    FRouter.FreeNotification(Self);
+end;
+
 procedure TAIUnifiedLLM.Notification(AComponent: TComponent;
   Operation: TOperation);
 begin
@@ -89,7 +100,8 @@ procedure TAIUnifiedLLM.ApplyRouter;
 var
   R: TAIModelRoute;
 begin
-  if not FAutoRoute then Exit;
+  if not FAutoRoute then
+    Exit;
   if FRouter = nil then
     raise Exception.Create('AutoRoute ativo sem TAIModelRouter configurado.');
 

--- a/pacote/AI/aiunifiedllm.pas
+++ b/pacote/AI/aiunifiedllm.pas
@@ -1,0 +1,178 @@
+unit aiunifiedllm;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, aibase, aillmproviders, aicapabilities, aimodelrouter;
+
+type
+  { TAIUnifiedLLM }
+
+  TAIUnifiedLLM = class(TAIBaseComponent)
+  private
+    FProviderKind: TAILLMProviderKind;
+    FEndpoint: string;
+    FToken: string;
+    FModel: string;
+    FSystemPrompt: string;
+    FTimeout: Integer;
+    FMaxTokens: Integer;
+    FTemperature: Double;
+    FStream: Boolean;
+    FAutoRoute: Boolean;
+    FPreferLocal: Boolean;
+    FRequiredCapabilities: TAICapabilities;
+    FRouter: TAIModelRouter;
+    FOnStreamData: TAILLMStreamDataEvent;
+    FProvider: IAILLMProvider;
+    procedure ApplyRouter;
+  protected
+    procedure Notification(AComponent: TComponent; Operation: TOperation); override;
+  public
+    constructor Create(AOwner: TComponent); override;
+    procedure Cancel;
+    function Ask(const AUserPrompt: string): Boolean;
+    function AskText(const AUserPrompt: string): string;
+    function ProviderCapabilities: TAICapabilities;
+    function Supports(ACapability: TAICapability): Boolean;
+    property RequiredCapabilities: TAICapabilities read FRequiredCapabilities write FRequiredCapabilities;
+  published
+    property ProviderKind: TAILLMProviderKind read FProviderKind write FProviderKind default llmOpenAICompatible;
+    property Endpoint: string read FEndpoint write FEndpoint;
+    property Token: string read FToken write FToken;
+    property Model: string read FModel write FModel;
+    property SystemPrompt: string read FSystemPrompt write FSystemPrompt;
+    property Timeout: Integer read FTimeout write FTimeout default 120000;
+    property MaxTokens: Integer read FMaxTokens write FMaxTokens default 1000;
+    property Temperature: Double read FTemperature write FTemperature;
+    property Stream: Boolean read FStream write FStream default False;
+    property AutoRoute: Boolean read FAutoRoute write FAutoRoute default False;
+    property PreferLocal: Boolean read FPreferLocal write FPreferLocal default True;
+    property Router: TAIModelRouter read FRouter write FRouter;
+    property OnStreamData: TAILLMStreamDataEvent read FOnStreamData write FOnStreamData;
+  end;
+
+procedure Register;
+
+implementation
+
+procedure Register;
+begin
+  RegisterComponents('AI Core', [TAIUnifiedLLM]);
+end;
+
+constructor TAIUnifiedLLM.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccModel;
+  FProviderKind := llmOpenAICompatible;
+  FTimeout := 120000;
+  FMaxTokens := 1000;
+  FTemperature := 0.7;
+  FStream := False;
+  FAutoRoute := False;
+  FPreferLocal := True;
+  FRequiredCapabilities := [aicChat];
+end;
+
+procedure TAIUnifiedLLM.Notification(AComponent: TComponent;
+  Operation: TOperation);
+begin
+  inherited Notification(AComponent, Operation);
+  if (Operation = opRemove) and (AComponent = FRouter) then
+    FRouter := nil;
+end;
+
+procedure TAIUnifiedLLM.ApplyRouter;
+var
+  R: TAIModelRoute;
+begin
+  if not FAutoRoute then Exit;
+  if FRouter = nil then
+    raise Exception.Create('AutoRoute ativo sem TAIModelRouter configurado.');
+
+  FRouter.PreferLocal := FPreferLocal;
+  R := FRouter.Select(FRequiredCapabilities);
+  if R = nil then
+    raise Exception.Create(FRouter.LastError);
+
+  FProviderKind := R.ProviderKind;
+  FModel := R.Model;
+  FEndpoint := R.Endpoint;
+  FToken := R.Token;
+end;
+
+function TAIUnifiedLLM.Ask(const AUserPrompt: string): Boolean;
+var
+  Cfg: TAILLMProviderConfig;
+  Answer: string;
+begin
+  ClearError;
+  FLastResult := '';
+  Result := False;
+
+  try
+    ApplyRouter;
+    FProvider := TAILLMProviderFactory.CreateProvider(FProviderKind);
+    if FProvider = nil then
+      raise Exception.Create('Nao foi possivel criar provider LLM.');
+
+    InitAILLMProviderConfig(Cfg);
+    Cfg.Endpoint := FEndpoint;
+    Cfg.Token := FToken;
+    Cfg.Model := FModel;
+    Cfg.SystemPrompt := FSystemPrompt;
+    Cfg.UserPrompt := AUserPrompt;
+    Cfg.Timeout := FTimeout;
+    Cfg.MaxTokens := FMaxTokens;
+    Cfg.Temperature := FTemperature;
+    Cfg.Stream := FStream;
+
+    Result := FProvider.Send(Cfg, FOnStreamData, Answer);
+    if Result then
+    begin
+      FLastResult := Answer;
+      FLastSuccess := True;
+    end
+    else
+      SetError(FProvider.GetLastError);
+  except
+    on E: Exception do
+      SetError(E.Message);
+  end;
+end;
+
+function TAIUnifiedLLM.AskText(const AUserPrompt: string): string;
+begin
+  if Ask(AUserPrompt) then
+    Result := FLastResult
+  else
+    Result := '';
+end;
+
+procedure TAIUnifiedLLM.Cancel;
+begin
+  if FProvider <> nil then
+    FProvider.Cancel;
+end;
+
+function TAIUnifiedLLM.ProviderCapabilities: TAICapabilities;
+var
+  Registry: TAICapabilityRegistry;
+begin
+  Registry := TAICapabilityRegistry.Create(nil);
+  try
+    Result := Registry.CapabilitiesOf(FProviderKind);
+  finally
+    Registry.Free;
+  end;
+end;
+
+function TAIUnifiedLLM.Supports(ACapability: TAICapability): Boolean;
+begin
+  Result := ACapability in ProviderCapabilities;
+end;
+
+end.

--- a/pacote/packages/openai_a2a.lpk
+++ b/pacote/packages/openai_a2a.lpk
@@ -21,11 +21,18 @@
         <HasRegisterProc Value="True"/>
         <UnitName Value="aia2a"/>
       </Item>
+      <Item>
+        <Filename Value="..\AI A2A\aia2aserver.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aia2aserver"/>
+      </Item>
     </Files>
     <RequiredPkgs>
       <Item><PackageName Value="LCL"/></Item>
       <Item><PackageName Value="FCL"/></Item>
       <Item><PackageName Value="openai_core"/></Item>
+      <Item><PackageName Value="openai_agent"/></Item>
+      <Item><PackageName Value="openai_input"/></Item>
     </RequiredPkgs>
     <UsageOptions><UnitPath Value="$(PkgOutDir)"/></UsageOptions>
     <PublishOptions><Version Value="2"/><UseFileFilters Value="True"/></PublishOptions>

--- a/pacote/packages/openai_a2a.lpk
+++ b/pacote/packages/openai_a2a.lpk
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <Package Version="5">
+    <PathDelim Value="\"/>
+    <Name Value="openai_a2a"/>
+    <Type Value="RunAndDesignTime"/>
+    <Author Value="Marcelo Maurin Martins"/>
+    <CompilerOptions>
+      <Version Value="11"/>
+      <PathDelim Value="\"/>
+      <SearchPaths>
+        <OtherUnitFiles Value="..\AI A2A;..\AI"/>
+        <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      </SearchPaths>
+    </CompilerOptions>
+    <Description Value="Lazarus AI Suite: Agent2Agent (A2A) protocol components for Free Pascal."/>
+    <License Value="OPEN SOURCE GPL3"/>
+    <Files>
+      <Item>
+        <Filename Value="..\AI A2A\aia2a.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aia2a"/>
+      </Item>
+    </Files>
+    <RequiredPkgs>
+      <Item><PackageName Value="LCL"/></Item>
+      <Item><PackageName Value="FCL"/></Item>
+      <Item><PackageName Value="openai_core"/></Item>
+    </RequiredPkgs>
+    <UsageOptions><UnitPath Value="$(PkgOutDir)"/></UsageOptions>
+    <PublishOptions><Version Value="2"/><UseFileFilters Value="True"/></PublishOptions>
+  </Package>
+</CONFIG>

--- a/pacote/packages/openai_agent.lpk
+++ b/pacote/packages/openai_agent.lpk
@@ -16,24 +16,88 @@
     <Description Value="Lazarus AI Suite: Autonomous agents, planning options, executors and safety locks."/>
     <License Value="OPEN SOURCE GPL3"/>
     <Files>
-      <Item><Filename Value="..\AI Agent\aiagent.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent"/></Item>
-      <Item><Filename Value="..\AI Agent\aiwizardconfig.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiwizardconfig"/></Item>
-      <Item><Filename Value="..\AI Agent\frm_aiwizardconfig.pas"/><UnitName Value="frm_aiwizardconfig"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagentserial.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentserial"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagent_flowevents.pas"/><UnitName Value="aiagent_flowevents"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagent_memorymap.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_memorymap"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagent_core.pas"/><UnitName Value="aiagent_core"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagent_classifier.pas"/><UnitName Value="aiagent_classifier"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagent_decision.pas"/><UnitName Value="aiagent_decision"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagent_actionbuilder.pas"/><UnitName Value="aiagent_actionbuilder"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagent_actions.pas"/><UnitName Value="aiagent_actions"/></Item>
-      <Item><Filename Value="..\AI Agent\aitools.pas"/><HasRegisterProc Value="True"/><UnitName Value="aitools"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagentgraph.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentgraph"/></Item>
-      <Item><Filename Value="..\AI Agent\aiguardrails.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiguardrails"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagent_executor.pas"/><UnitName Value="aiagent_executor"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagent_orchestrator.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_orchestrator"/></Item>
-      <Item><Filename Value="..\AI Agent\aiagentsafety.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentsafety"/></Item>
-      <Item><Filename Value="..\AI Agent\aidevagents.pas"/><HasRegisterProc Value="True"/><UnitName Value="aidevagents"/></Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiagent"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiwizardconfig.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiwizardconfig"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\frm_aiwizardconfig.pas"/>
+        <UnitName Value="frm_aiwizardconfig"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagentserial.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiagentserial"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent_flowevents.pas"/>
+        <UnitName Value="aiagent_flowevents"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent_memorymap.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiagent_memorymap"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent_core.pas"/>
+        <UnitName Value="aiagent_core"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent_classifier.pas"/>
+        <UnitName Value="aiagent_classifier"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent_decision.pas"/>
+        <UnitName Value="aiagent_decision"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent_actionbuilder.pas"/>
+        <UnitName Value="aiagent_actionbuilder"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent_actions.pas"/>
+        <UnitName Value="aiagent_actions"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aitools.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aitools"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagentgraph.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiagentgraph"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiguardrails.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiguardrails"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent_executor.pas"/>
+        <UnitName Value="aiagent_executor"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagent_orchestrator.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiagent_orchestrator"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiagentsafety.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiagentsafety"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aidevagents.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aidevagents"/>
+      </Item>
     </Files>
     <RequiredPkgs>
       <Item><PackageName Value="GLScene_DesignTime"/></Item>
@@ -44,7 +108,12 @@
       <Item><PackageName Value="LCL"/></Item>
       <Item><PackageName Value="FCL"/></Item>
     </RequiredPkgs>
-    <UsageOptions><UnitPath Value="$(PkgOutDir)"/></UsageOptions>
-    <PublishOptions><Version Value="2"/><UseFileFilters Value="True"/></PublishOptions>
+    <UsageOptions>
+      <UnitPath Value="$(PkgOutDir)"/>
+    </UsageOptions>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
   </Package>
 </CONFIG>

--- a/pacote/packages/openai_agent.lpk
+++ b/pacote/packages/openai_agent.lpk
@@ -16,113 +16,35 @@
     <Description Value="Lazarus AI Suite: Autonomous agents, planning options, executors and safety locks."/>
     <License Value="OPEN SOURCE GPL3"/>
     <Files>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagent"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiwizardconfig.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiwizardconfig"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\frm_aiwizardconfig.pas"/>
-        <UnitName Value="frm_aiwizardconfig"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagentserial.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagentserial"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_flowevents.pas"/>
-        <UnitName Value="aiagent_flowevents"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_memorymap.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagent_memorymap"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_core.pas"/>
-        <UnitName Value="aiagent_core"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_classifier.pas"/>
-        <UnitName Value="aiagent_classifier"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_decision.pas"/>
-        <UnitName Value="aiagent_decision"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_actionbuilder.pas"/>
-        <UnitName Value="aiagent_actionbuilder"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_actions.pas"/>
-        <UnitName Value="aiagent_actions"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aitools.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aitools"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagentgraph.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagentgraph"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiguardrails.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiguardrails"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_executor.pas"/>
-        <UnitName Value="aiagent_executor"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_orchestrator.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagent_orchestrator"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagentsafety.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagentsafety"/>
-      </Item>
+      <Item><Filename Value="..\AI Agent\aiagent.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent"/></Item>
+      <Item><Filename Value="..\AI Agent\aiwizardconfig.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiwizardconfig"/></Item>
+      <Item><Filename Value="..\AI Agent\frm_aiwizardconfig.pas"/><UnitName Value="frm_aiwizardconfig"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagentserial.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentserial"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_flowevents.pas"/><UnitName Value="aiagent_flowevents"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_memorymap.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_memorymap"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_core.pas"/><UnitName Value="aiagent_core"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_classifier.pas"/><UnitName Value="aiagent_classifier"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_decision.pas"/><UnitName Value="aiagent_decision"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_actionbuilder.pas"/><UnitName Value="aiagent_actionbuilder"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_actions.pas"/><UnitName Value="aiagent_actions"/></Item>
+      <Item><Filename Value="..\AI Agent\aitools.pas"/><HasRegisterProc Value="True"/><UnitName Value="aitools"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagentgraph.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentgraph"/></Item>
+      <Item><Filename Value="..\AI Agent\aiguardrails.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiguardrails"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_executor.pas"/><UnitName Value="aiagent_executor"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_orchestrator.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_orchestrator"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagentsafety.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentsafety"/></Item>
+      <Item><Filename Value="..\AI Agent\aidevagents.pas"/><HasRegisterProc Value="True"/><UnitName Value="aidevagents"/></Item>
     </Files>
     <RequiredPkgs>
-      <Item>
-        <PackageName Value="GLScene_DesignTime"/>
-      </Item>
-      <Item>
-        <PackageName Value="openai_core"/>
-      </Item>
-      <Item>
-        <PackageName Value="openai_ml"/>
-      </Item>
-      <Item>
-        <PackageName Value="openai_input"/>
-      </Item>
-      <Item>
-        <PackageName Value="openai_output"/>
-      </Item>
-      <Item>
-        <PackageName Value="LCL"/>
-      </Item>
-      <Item>
-        <PackageName Value="FCL"/>
-      </Item>
+      <Item><PackageName Value="GLScene_DesignTime"/></Item>
+      <Item><PackageName Value="openai_core"/></Item>
+      <Item><PackageName Value="openai_ml"/></Item>
+      <Item><PackageName Value="openai_input"/></Item>
+      <Item><PackageName Value="openai_output"/></Item>
+      <Item><PackageName Value="LCL"/></Item>
+      <Item><PackageName Value="FCL"/></Item>
     </RequiredPkgs>
-    <UsageOptions>
-      <UnitPath Value="$(PkgOutDir)"/>
-    </UsageOptions>
-    <PublishOptions>
-      <Version Value="2"/>
-      <UseFileFilters Value="True"/>
-    </PublishOptions>
+    <UsageOptions><UnitPath Value="$(PkgOutDir)"/></UsageOptions>
+    <PublishOptions><Version Value="2"/><UseFileFilters Value="True"/></PublishOptions>
   </Package>
 </CONFIG>

--- a/pacote/packages/openai_agent.lpk
+++ b/pacote/packages/openai_agent.lpk
@@ -16,93 +16,26 @@
     <Description Value="Lazarus AI Suite: Autonomous agents, planning options, executors and safety locks."/>
     <License Value="OPEN SOURCE GPL3"/>
     <Files>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagent"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiwizardconfig.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiwizardconfig"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\frm_aiwizardconfig.pas"/>
-        <UnitName Value="frm_aiwizardconfig"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagentserial.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagentserial"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_flowevents.pas"/>
-        <UnitName Value="aiagent_flowevents"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_memorymap.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagent_memorymap"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_core.pas"/>
-        <UnitName Value="aiagent_core"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_classifier.pas"/>
-        <UnitName Value="aiagent_classifier"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_decision.pas"/>
-        <UnitName Value="aiagent_decision"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_actionbuilder.pas"/>
-        <UnitName Value="aiagent_actionbuilder"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_actions.pas"/>
-        <UnitName Value="aiagent_actions"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aitools.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aitools"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagentgraph.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagentgraph"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiguardrails.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiguardrails"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_executor.pas"/>
-        <UnitName Value="aiagent_executor"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagent_orchestrator.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagent_orchestrator"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiagentsafety.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiagentsafety"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aidevagents.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aidevagents"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Agent\aiserviceagents.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aiserviceagents"/>
-      </Item>
+      <Item><Filename Value="..\AI Agent\aiagent.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent"/></Item>
+      <Item><Filename Value="..\AI Agent\aiwizardconfig.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiwizardconfig"/></Item>
+      <Item><Filename Value="..\AI Agent\frm_aiwizardconfig.pas"/><UnitName Value="frm_aiwizardconfig"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagentserial.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentserial"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_flowevents.pas"/><UnitName Value="aiagent_flowevents"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_memorymap.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_memorymap"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_core.pas"/><UnitName Value="aiagent_core"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_classifier.pas"/><UnitName Value="aiagent_classifier"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_decision.pas"/><UnitName Value="aiagent_decision"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_actionbuilder.pas"/><UnitName Value="aiagent_actionbuilder"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_actions.pas"/><UnitName Value="aiagent_actions"/></Item>
+      <Item><Filename Value="..\AI Agent\aitools.pas"/><HasRegisterProc Value="True"/><UnitName Value="aitools"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagentgraph.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentgraph"/></Item>
+      <Item><Filename Value="..\AI Agent\aiguardrails.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiguardrails"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_executor.pas"/><UnitName Value="aiagent_executor"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_orchestrator.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_orchestrator"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagentsafety.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentsafety"/></Item>
+      <Item><Filename Value="..\AI Agent\aidevagents.pas"/><HasRegisterProc Value="True"/><UnitName Value="aidevagents"/></Item>
+      <Item><Filename Value="..\AI Agent\aiserviceagents.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiserviceagents"/></Item>
+      <Item><Filename Value="..\AI Agent\aicommonserviceagents.pas"/><HasRegisterProc Value="True"/><UnitName Value="aicommonserviceagents"/></Item>
     </Files>
     <RequiredPkgs>
       <Item><PackageName Value="GLScene_DesignTime"/></Item>
@@ -113,12 +46,7 @@
       <Item><PackageName Value="LCL"/></Item>
       <Item><PackageName Value="FCL"/></Item>
     </RequiredPkgs>
-    <UsageOptions>
-      <UnitPath Value="$(PkgOutDir)"/>
-    </UsageOptions>
-    <PublishOptions>
-      <Version Value="2"/>
-      <UseFileFilters Value="True"/>
-    </PublishOptions>
+    <UsageOptions><UnitPath Value="$(PkgOutDir)"/></UsageOptions>
+    <PublishOptions><Version Value="2"/><UseFileFilters Value="True"/></PublishOptions>
   </Package>
 </CONFIG>

--- a/pacote/packages/openai_agent.lpk
+++ b/pacote/packages/openai_agent.lpk
@@ -98,6 +98,11 @@
         <HasRegisterProc Value="True"/>
         <UnitName Value="aidevagents"/>
       </Item>
+      <Item>
+        <Filename Value="..\AI Agent\aiserviceagents.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiserviceagents"/>
+      </Item>
     </Files>
     <RequiredPkgs>
       <Item><PackageName Value="GLScene_DesignTime"/></Item>

--- a/pacote/packages/openai_core.lpk
+++ b/pacote/packages/openai_core.lpk
@@ -16,105 +16,34 @@
     <Description Value="Lazarus AI Suite: Core components, platform helpers and runtime infrastructure."/>
     <License Value="OPEN SOURCE GPL3"/>
     <Files>
-      <Item>
-        <Filename Value="..\funcoes.pas"/>
-        <UnitName Value="funcoes"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aibase.pas"/>
-        <UnitName Value="aibase"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\airagbridge.pas"/>
-        <UnitName Value="airagbridge"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aitracebridge.pas"/>
-        <UnitName Value="aitracebridge"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aillmproviders.pas"/>
-        <UnitName Value="aillmproviders"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aillmmodelcatalog.pas"/>
-        <UnitName Value="aillmmodelcatalog"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aiplatform.pas"/>
-        <UnitName Value="aiplatform"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\airuntimepaths.pas"/>
-        <UnitName Value="airuntimepaths"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\ailibraryloader.pas"/>
-        <UnitName Value="ailibraryloader"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aiprocessrunner.pas"/>
-        <UnitName Value="aiprocessrunner"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aimodelmanager.pas"/>
-        <UnitName Value="aimodelmanager"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\chatgpt.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="chatgpt"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\tokenizer.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="tokenizer"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aicodeassistant.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aicodeassistant"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aipromptbuilder.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aipromptbuilder"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\aimodelregistry.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="aimodelregistry"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\dbtokenlist.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="dbtokenlist"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI\groupresponse.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="groupresponse"/>
-      </Item>
-      <Item>
-        <Filename Value="..\AI Schedule\iaschedule.pas"/>
-        <HasRegisterProc Value="True"/>
-        <UnitName Value="iaschedule"/>
-      </Item>
+      <Item><Filename Value="..\funcoes.pas"/><UnitName Value="funcoes"/></Item>
+      <Item><Filename Value="..\AI\aibase.pas"/><UnitName Value="aibase"/></Item>
+      <Item><Filename Value="..\AI\airagbridge.pas"/><UnitName Value="airagbridge"/></Item>
+      <Item><Filename Value="..\AI\aitracebridge.pas"/><UnitName Value="aitracebridge"/></Item>
+      <Item><Filename Value="..\AI\aillmproviders.pas"/><UnitName Value="aillmproviders"/></Item>
+      <Item><Filename Value="..\AI\aillmmodelcatalog.pas"/><UnitName Value="aillmmodelcatalog"/></Item>
+      <Item><Filename Value="..\AI\aicapabilities.pas"/><UnitName Value="aicapabilities"/></Item>
+      <Item><Filename Value="..\AI\aimodelrouter.pas"/><HasRegisterProc Value="True"/><UnitName Value="aimodelrouter"/></Item>
+      <Item><Filename Value="..\AI\aiunifiedllm.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiunifiedllm"/></Item>
+      <Item><Filename Value="..\AI\aiplatform.pas"/><UnitName Value="aiplatform"/></Item>
+      <Item><Filename Value="..\AI\airuntimepaths.pas"/><UnitName Value="airuntimepaths"/></Item>
+      <Item><Filename Value="..\AI\ailibraryloader.pas"/><UnitName Value="ailibraryloader"/></Item>
+      <Item><Filename Value="..\AI\aiprocessrunner.pas"/><UnitName Value="aiprocessrunner"/></Item>
+      <Item><Filename Value="..\AI\aimodelmanager.pas"/><UnitName Value="aimodelmanager"/></Item>
+      <Item><Filename Value="..\AI\chatgpt.pas"/><HasRegisterProc Value="True"/><UnitName Value="chatgpt"/></Item>
+      <Item><Filename Value="..\AI\tokenizer.pas"/><HasRegisterProc Value="True"/><UnitName Value="tokenizer"/></Item>
+      <Item><Filename Value="..\AI\aicodeassistant.pas"/><HasRegisterProc Value="True"/><UnitName Value="aicodeassistant"/></Item>
+      <Item><Filename Value="..\AI\aipromptbuilder.pas"/><HasRegisterProc Value="True"/><UnitName Value="aipromptbuilder"/></Item>
+      <Item><Filename Value="..\AI\aimodelregistry.pas"/><HasRegisterProc Value="True"/><UnitName Value="aimodelregistry"/></Item>
+      <Item><Filename Value="..\AI\dbtokenlist.pas"/><HasRegisterProc Value="True"/><UnitName Value="dbtokenlist"/></Item>
+      <Item><Filename Value="..\AI\groupresponse.pas"/><HasRegisterProc Value="True"/><UnitName Value="groupresponse"/></Item>
+      <Item><Filename Value="..\AI Schedule\iaschedule.pas"/><HasRegisterProc Value="True"/><UnitName Value="iaschedule"/></Item>
     </Files>
     <RequiredPkgs>
-      <Item>
-        <PackageName Value="zcomponent"/>
-      </Item>
-      <Item>
-        <PackageName Value="TurboPowerIpro"/>
-      </Item>
+      <Item><PackageName Value="zcomponent"/></Item>
+      <Item><PackageName Value="TurboPowerIpro"/></Item>
     </RequiredPkgs>
-    <UsageOptions>
-      <UnitPath Value="$(PkgOutDir)"/>
-    </UsageOptions>
-    <PublishOptions>
-      <Version Value="2"/>
-      <UseFileFilters Value="True"/>
-    </PublishOptions>
+    <UsageOptions><UnitPath Value="$(PkgOutDir)"/></UsageOptions>
+    <PublishOptions><Version Value="2"/><UseFileFilters Value="True"/></PublishOptions>
   </Package>
 </CONFIG>

--- a/pacote/packages/openai_core.lpk
+++ b/pacote/packages/openai_core.lpk
@@ -16,34 +16,119 @@
     <Description Value="Lazarus AI Suite: Core components, platform helpers and runtime infrastructure."/>
     <License Value="OPEN SOURCE GPL3"/>
     <Files>
-      <Item><Filename Value="..\funcoes.pas"/><UnitName Value="funcoes"/></Item>
-      <Item><Filename Value="..\AI\aibase.pas"/><UnitName Value="aibase"/></Item>
-      <Item><Filename Value="..\AI\airagbridge.pas"/><UnitName Value="airagbridge"/></Item>
-      <Item><Filename Value="..\AI\aitracebridge.pas"/><UnitName Value="aitracebridge"/></Item>
-      <Item><Filename Value="..\AI\aillmproviders.pas"/><UnitName Value="aillmproviders"/></Item>
-      <Item><Filename Value="..\AI\aillmmodelcatalog.pas"/><UnitName Value="aillmmodelcatalog"/></Item>
-      <Item><Filename Value="..\AI\aicapabilities.pas"/><UnitName Value="aicapabilities"/></Item>
-      <Item><Filename Value="..\AI\aimodelrouter.pas"/><HasRegisterProc Value="True"/><UnitName Value="aimodelrouter"/></Item>
-      <Item><Filename Value="..\AI\aiunifiedllm.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiunifiedllm"/></Item>
-      <Item><Filename Value="..\AI\aiplatform.pas"/><UnitName Value="aiplatform"/></Item>
-      <Item><Filename Value="..\AI\airuntimepaths.pas"/><UnitName Value="airuntimepaths"/></Item>
-      <Item><Filename Value="..\AI\ailibraryloader.pas"/><UnitName Value="ailibraryloader"/></Item>
-      <Item><Filename Value="..\AI\aiprocessrunner.pas"/><UnitName Value="aiprocessrunner"/></Item>
-      <Item><Filename Value="..\AI\aimodelmanager.pas"/><UnitName Value="aimodelmanager"/></Item>
-      <Item><Filename Value="..\AI\chatgpt.pas"/><HasRegisterProc Value="True"/><UnitName Value="chatgpt"/></Item>
-      <Item><Filename Value="..\AI\tokenizer.pas"/><HasRegisterProc Value="True"/><UnitName Value="tokenizer"/></Item>
-      <Item><Filename Value="..\AI\aicodeassistant.pas"/><HasRegisterProc Value="True"/><UnitName Value="aicodeassistant"/></Item>
-      <Item><Filename Value="..\AI\aipromptbuilder.pas"/><HasRegisterProc Value="True"/><UnitName Value="aipromptbuilder"/></Item>
-      <Item><Filename Value="..\AI\aimodelregistry.pas"/><HasRegisterProc Value="True"/><UnitName Value="aimodelregistry"/></Item>
-      <Item><Filename Value="..\AI\dbtokenlist.pas"/><HasRegisterProc Value="True"/><UnitName Value="dbtokenlist"/></Item>
-      <Item><Filename Value="..\AI\groupresponse.pas"/><HasRegisterProc Value="True"/><UnitName Value="groupresponse"/></Item>
-      <Item><Filename Value="..\AI Schedule\iaschedule.pas"/><HasRegisterProc Value="True"/><UnitName Value="iaschedule"/></Item>
+      <Item>
+        <Filename Value="..\funcoes.pas"/>
+        <UnitName Value="funcoes"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aibase.pas"/>
+        <UnitName Value="aibase"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\airagbridge.pas"/>
+        <UnitName Value="airagbridge"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aitracebridge.pas"/>
+        <UnitName Value="aitracebridge"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aillmproviders.pas"/>
+        <UnitName Value="aillmproviders"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aillmmodelcatalog.pas"/>
+        <UnitName Value="aillmmodelcatalog"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aicapabilities.pas"/>
+        <UnitName Value="aicapabilities"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aimodelrouter.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aimodelrouter"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aiunifiedllm.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aiunifiedllm"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aiplatform.pas"/>
+        <UnitName Value="aiplatform"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\airuntimepaths.pas"/>
+        <UnitName Value="airuntimepaths"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\ailibraryloader.pas"/>
+        <UnitName Value="ailibraryloader"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aiprocessrunner.pas"/>
+        <UnitName Value="aiprocessrunner"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aimodelmanager.pas"/>
+        <UnitName Value="aimodelmanager"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\chatgpt.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="chatgpt"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\tokenizer.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="tokenizer"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aicodeassistant.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aicodeassistant"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aipromptbuilder.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aipromptbuilder"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\aimodelregistry.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="aimodelregistry"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\dbtokenlist.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="dbtokenlist"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI\groupresponse.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="groupresponse"/>
+      </Item>
+      <Item>
+        <Filename Value="..\AI Schedule\iaschedule.pas"/>
+        <HasRegisterProc Value="True"/>
+        <UnitName Value="iaschedule"/>
+      </Item>
     </Files>
     <RequiredPkgs>
-      <Item><PackageName Value="zcomponent"/></Item>
-      <Item><PackageName Value="TurboPowerIpro"/></Item>
+      <Item>
+        <PackageName Value="zcomponent"/>
+      </Item>
+      <Item>
+        <PackageName Value="TurboPowerIpro"/>
+      </Item>
     </RequiredPkgs>
-    <UsageOptions><UnitPath Value="$(PkgOutDir)"/></UsageOptions>
-    <PublishOptions><Version Value="2"/><UseFileFilters Value="True"/></PublishOptions>
+    <UsageOptions>
+      <UnitPath Value="$(PkgOutDir)"/>
+    </UsageOptions>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
   </Package>
 </CONFIG>

--- a/pacote/samples/AI A2A/a2a_client_demo/a2a_client_demo.lpi
+++ b/pacote/samples/AI A2A/a2a_client_demo/a2a_client_demo.lpi
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="a2a_client_demo"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes><Item Name="Default" Default="True"/></BuildModes>
+    <RequiredPackages>
+      <Item><PackageName Value="openai_a2a"/></Item>
+    </RequiredPackages>
+    <Units>
+      <Unit><Filename Value="a2a_client_demo.lpr"/><IsPartOfProject Value="True"/></Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target><Filename Value="a2a_client_demo"/></Target>
+    <SearchPaths><UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/></SearchPaths>
+    <Parsing><SyntaxOptions><UseAnsiStrings Value="True"/></SyntaxOptions></Parsing>
+  </CompilerOptions>
+</CONFIG>

--- a/pacote/samples/AI A2A/a2a_client_demo/a2a_client_demo.lpr
+++ b/pacote/samples/AI A2A/a2a_client_demo/a2a_client_demo.lpr
@@ -1,0 +1,52 @@
+program a2a_client_demo;
+
+{$mode objfpc}{$H+}
+
+uses
+  {$IFDEF UNIX}
+  cthreads,
+  {$ENDIF}
+  Classes, SysUtils, aia2a;
+
+var
+  Client: TAIA2AClient;
+  Answer: string;
+begin
+  Client := TAIA2AClient.Create(nil);
+  try
+    Client.ProtocolVersion := '1.0';
+    Client.Binding := a2abHTTPJSON;
+    Client.AutoDiscover := True;
+
+    if ParamCount = 0 then
+    begin
+      WriteLn('A2A client demo - Lazarus/Free Pascal');
+      WriteLn('Usage: a2a_client_demo <base-url> [message]');
+      Halt(0);
+    end;
+
+    Client.BaseURL := ParamStr(1);
+    if not Client.Discover then
+    begin
+      WriteLn(StdErr, 'Discovery error: ', Client.LastError);
+      Halt(1);
+    end;
+
+    WriteLn('Agent: ', Client.AgentCard.Name);
+    WriteLn('Version: ', Client.AgentCard.Version);
+    WriteLn('Endpoint: ', Client.SelectedURL);
+
+    if ParamCount >= 2 then
+    begin
+      if Client.SendText(ParamStr(2), Answer) then
+        WriteLn('Answer: ', Answer)
+      else
+      begin
+        WriteLn(StdErr, 'Send error: ', Client.LastError);
+        Halt(2);
+      end;
+    end;
+  finally
+    Client.Free;
+  end;
+end.

--- a/pacote/samples/AI Agent/common_service_agents_demo/common_service_agents_demo.lpi
+++ b/pacote/samples/AI Agent/common_service_agents_demo/common_service_agents_demo.lpi
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="common_service_agents_demo"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes><Item Name="Default" Default="True"/></BuildModes>
+    <RequiredPackages><Item><PackageName Value="openai_agent"/></Item></RequiredPackages>
+    <Units><Unit><Filename Value="common_service_agents_demo.lpr"/><IsPartOfProject Value="True"/></Unit></Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target><Filename Value="common_service_agents_demo"/></Target>
+    <SearchPaths><UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/></SearchPaths>
+    <Parsing><SyntaxOptions><UseAnsiStrings Value="True"/></SyntaxOptions></Parsing>
+  </CompilerOptions>
+</CONFIG>

--- a/pacote/samples/AI Agent/common_service_agents_demo/common_service_agents_demo.lpr
+++ b/pacote/samples/AI Agent/common_service_agents_demo/common_service_agents_demo.lpr
@@ -1,0 +1,63 @@
+program common_service_agents_demo;
+
+{$mode objfpc}{$H+}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  Classes, SysUtils, aicommonserviceagents;
+
+var
+  GitLab: TAIGitLabAgent;
+  Telegram: TAITelegramAgent;
+  Email: TAIEmailAgent;
+  RSS: TAIRSSAgent;
+  Web: TAIWebAgent;
+  SSH: TAISSHAgent;
+  Database: TAIDatabaseAgent;
+  WhatsApp: TAIWhatsAppAgent;
+begin
+  GitLab := TAIGitLabAgent.Create(nil);
+  Telegram := TAITelegramAgent.Create(nil);
+  Email := TAIEmailAgent.Create(nil);
+  RSS := TAIRSSAgent.Create(nil);
+  Web := TAIWebAgent.Create(nil);
+  SSH := TAISSHAgent.Create(nil);
+  Database := TAIDatabaseAgent.Create(nil);
+  WhatsApp := TAIWhatsAppAgent.Create(nil);
+  try
+    GitLab.ProjectID := 'group/project';
+    Telegram.ChatID := 'CHAT_ID';
+    RSS.FeedURL := 'https://example.com/feed.xml';
+    SSH.Host := 'server.example.com';
+    WhatsApp.PhoneNumberID := 'PHONE_NUMBER_ID';
+
+    { Escrita e execucao ficam bloqueadas por padrao. }
+    GitLab.AllowWrite := False;
+    Telegram.AllowWrite := False;
+    Email.AllowWrite := False;
+    Web.AllowWrite := False;
+    SSH.AllowWrite := False;
+    Database.AllowWrite := False;
+    WhatsApp.AllowWrite := False;
+
+    WriteLn('CHATGPT Lazarus common service agents');
+    WriteLn(' GitLab   : ready');
+    WriteLn(' Telegram : ready');
+    WriteLn(' Email    : ready (reuses TAIEmailClient)');
+    WriteLn(' RSS/Atom : ready');
+    WriteLn(' Web      : ready');
+    WriteLn(' SSH      : ready');
+    WriteLn(' Database : ready (TSQLConnection)');
+    WriteLn(' WhatsApp : ready (Cloud API)');
+    WriteLn('All write actions are disabled by default.');
+  finally
+    WhatsApp.Free;
+    Database.Free;
+    SSH.Free;
+    Web.Free;
+    RSS.Free;
+    Email.Free;
+    Telegram.Free;
+    GitLab.Free;
+  end;
+end.

--- a/pacote/samples/AI Agent/dev_agents_demo/dev_agents_demo.lpi
+++ b/pacote/samples/AI Agent/dev_agents_demo/dev_agents_demo.lpi
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="dev_agents_demo"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes><Item Name="Default" Default="True"/></BuildModes>
+    <RequiredPackages>
+      <Item><PackageName Value="openai_agent"/></Item>
+    </RequiredPackages>
+    <Units>
+      <Unit><Filename Value="dev_agents_demo.lpr"/><IsPartOfProject Value="True"/></Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target><Filename Value="dev_agents_demo"/></Target>
+    <SearchPaths><UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/></SearchPaths>
+    <Parsing><SyntaxOptions><UseAnsiStrings Value="True"/></SyntaxOptions></Parsing>
+  </CompilerOptions>
+</CONFIG>

--- a/pacote/samples/AI Agent/dev_agents_demo/dev_agents_demo.lpr
+++ b/pacote/samples/AI Agent/dev_agents_demo/dev_agents_demo.lpr
@@ -1,0 +1,59 @@
+program dev_agents_demo;
+
+{$mode objfpc}{$H+}
+
+uses
+  {$IFDEF UNIX}
+  cthreads,
+  {$ENDIF}
+  Classes, SysUtils, aillmproviders, aimodelrouter, aiunifiedllm,
+  aidevagents;
+
+var
+  Router: TAIModelRouter;
+  LLM: TAIUnifiedLLM;
+  SourceAgent: TAISourceAgent;
+  BuildAgent: TAILazarusBuildAgent;
+  TestAgent: TAITestAgent;
+  NetworkAgent: TAINetworkAgent;
+begin
+  Router := TAIModelRouter.Create(nil);
+  LLM := TAIUnifiedLLM.Create(nil);
+  SourceAgent := TAISourceAgent.Create(nil);
+  BuildAgent := TAILazarusBuildAgent.Create(nil);
+  TestAgent := TAITestAgent.Create(nil);
+  NetworkAgent := TAINetworkAgent.Create(nil);
+  try
+    Router.PreferLocal := True;
+    Router.AddRoute(llmLlamaCpp, 'local-model', 'http://127.0.0.1:8080');
+
+    LLM.Router := Router;
+    LLM.AutoRoute := True;
+    LLM.PreferLocal := True;
+
+    SourceAgent.LLM := LLM;
+    SourceAgent.RootDirectory := GetCurrentDir;
+    SourceAgent.AllowWrite := False;
+
+    BuildAgent.LazBuildPath := 'lazbuild';
+    BuildAgent.TimeoutMs := 300000;
+
+    TestAgent.TimeoutMs := 120000;
+    NetworkAgent.TimeoutMs := 10000;
+
+    WriteLn('CHATGPT Lazarus development agents');
+    WriteLn('  SourceAgent: ready (write disabled by default)');
+    WriteLn('  BuildAgent : ready');
+    WriteLn('  TestAgent  : ready');
+    WriteLn('  NetworkAgent: ready');
+    WriteLn('  Preferred provider: ',
+      AILLMProviderKindName(Router.Select([aicChat]).ProviderKind));
+  finally
+    NetworkAgent.Free;
+    TestAgent.Free;
+    BuildAgent.Free;
+    SourceAgent.Free;
+    LLM.Free;
+    Router.Free;
+  end;
+end.

--- a/pacote/samples/AI Agent/dev_agents_demo/dev_agents_demo.lpr
+++ b/pacote/samples/AI Agent/dev_agents_demo/dev_agents_demo.lpr
@@ -6,8 +6,8 @@ uses
   {$IFDEF UNIX}
   cthreads,
   {$ENDIF}
-  Classes, SysUtils, aillmproviders, aimodelrouter, aiunifiedllm,
-  aidevagents;
+  Classes, SysUtils, aillmproviders, aicapabilities, aimodelrouter,
+  aiunifiedllm, aidevagents;
 
 var
   Router: TAIModelRouter;

--- a/pacote/samples/AI Agent/service_agents_demo/service_agents_demo.lpi
+++ b/pacote/samples/AI Agent/service_agents_demo/service_agents_demo.lpi
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="service_agents_demo"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes><Item Name="Default" Default="True"/></BuildModes>
+    <RequiredPackages>
+      <Item><PackageName Value="openai_agent"/></Item>
+    </RequiredPackages>
+    <Units>
+      <Unit><Filename Value="service_agents_demo.lpr"/><IsPartOfProject Value="True"/></Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target><Filename Value="service_agents_demo"/></Target>
+    <SearchPaths><UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/></SearchPaths>
+    <Parsing><SyntaxOptions><UseAnsiStrings Value="True"/></SyntaxOptions></Parsing>
+  </CompilerOptions>
+</CONFIG>

--- a/pacote/samples/AI Agent/service_agents_demo/service_agents_demo.lpr
+++ b/pacote/samples/AI Agent/service_agents_demo/service_agents_demo.lpr
@@ -1,0 +1,47 @@
+program service_agents_demo;
+
+{$mode objfpc}{$H+}
+
+uses
+  Classes, SysUtils, aiserviceagents;
+
+var
+  GitHub: TAIGitHubAgent;
+  Facebook: TAIFacebookAgent;
+  YouTube: TAIYouTubeAgent;
+begin
+  GitHub := TAIGitHubAgent.Create(nil);
+  Facebook := TAIFacebookAgent.Create(nil);
+  YouTube := TAIYouTubeAgent.Create(nil);
+  try
+    { GitHub }
+    GitHub.Owner := 'marcelomaurin';
+    GitHub.Repository := 'CHATGPT';
+    GitHub.AccessToken := ''; // opcional para leitura publica; necessario para escrita/privado
+    GitHub.AllowWrite := False;
+
+    { Facebook Page / Graph API }
+    Facebook.PageID := '';
+    Facebook.APIVersion := ''; // configure uma versao Graph API suportada pelo seu app
+    Facebook.AccessToken := ''; // Page Access Token
+    Facebook.AllowWrite := False;
+
+    { YouTube Data API v3 }
+    YouTube.ChannelID := '';
+    YouTube.APIKey := '';       // leitura publica
+    YouTube.AccessToken := '';  // OAuth 2.0 para dados privados/escrita
+    YouTube.AllowWrite := False;
+
+    WriteLn('CHATGPT Lazarus service agents');
+    WriteLn('  GitHubAgent  : ready');
+    WriteLn('  FacebookAgent: ready');
+    WriteLn('  YouTubeAgent : ready');
+    WriteLn;
+    WriteLn('Operacoes de escrita estao bloqueadas por padrao (AllowWrite=False).');
+    WriteLn('Configure tokens/IDs antes de chamar as APIs reais.');
+  finally
+    YouTube.Free;
+    Facebook.Free;
+    GitHub.Free;
+  end;
+end.

--- a/pacote/samples/AI Core/unified_llm_router_demo/unified_llm_router_demo.lpi
+++ b/pacote/samples/AI Core/unified_llm_router_demo/unified_llm_router_demo.lpi
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="unified_llm_router_demo"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes><Item Name="Default" Default="True"/></BuildModes>
+    <RequiredPackages>
+      <Item><PackageName Value="openai_core"/></Item>
+    </RequiredPackages>
+    <Units>
+      <Unit><Filename Value="unified_llm_router_demo.lpr"/><IsPartOfProject Value="True"/></Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target><Filename Value="unified_llm_router_demo"/></Target>
+    <SearchPaths><UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/></SearchPaths>
+    <Parsing><SyntaxOptions><UseAnsiStrings Value="True"/></SyntaxOptions></Parsing>
+  </CompilerOptions>
+</CONFIG>

--- a/pacote/samples/AI Core/unified_llm_router_demo/unified_llm_router_demo.lpr
+++ b/pacote/samples/AI Core/unified_llm_router_demo/unified_llm_router_demo.lpr
@@ -1,0 +1,68 @@
+program unified_llm_router_demo;
+
+{$mode objfpc}{$H+}
+
+uses
+  {$IFDEF UNIX}
+  cthreads,
+  {$ENDIF}
+  Classes, SysUtils, aillmproviders, aicapabilities, aimodelrouter,
+  aiunifiedllm;
+
+var
+  Router: TAIModelRouter;
+  LLM: TAIUnifiedLLM;
+  Answer: string;
+begin
+  Router := TAIModelRouter.Create(nil);
+  LLM := TAIUnifiedLLM.Create(nil);
+  try
+    Router.PreferLocal := True;
+
+    { Primeira opcao: llama.cpp local. }
+    Router.AddRoute(
+      llmLlamaCpp,
+      'local-model',
+      'http://127.0.0.1:8080',
+      '',
+      10
+    );
+
+    { Fallback: OpenAI compativel. Preencha endpoint/token se desejar. }
+    Router.AddRoute(
+      llmOpenAICompatible,
+      'fallback-model',
+      '',
+      '',
+      100
+    );
+
+    LLM.Router := Router;
+    LLM.AutoRoute := True;
+    LLM.PreferLocal := True;
+    LLM.RequiredCapabilities := [aicChat];
+    LLM.SystemPrompt := 'Responda de forma curta.';
+    LLM.MaxTokens := 128;
+
+    WriteLn('Rota selecionada: ', Router.Select([aicChat]).Model);
+    WriteLn('Provider: ', AILLMProviderKindName(Router.Select([aicChat]).ProviderKind));
+
+    if ParamCount = 0 then
+    begin
+      WriteLn('Uso: unified_llm_router_demo "sua pergunta"');
+      Halt(0);
+    end;
+
+    Answer := LLM.AskText(ParamStr(1));
+    if LLM.LastSuccess then
+      WriteLn(Answer)
+    else
+    begin
+      WriteLn(StdErr, 'Erro: ', LLM.LastError);
+      Halt(1);
+    end;
+  finally
+    LLM.Free;
+    Router.Free;
+  end;
+end.


### PR DESCRIPTION
## Objetivo
Evoluir o CHATGPT como framework nativo de IA para Lazarus/Free Pascal, sem Delphi/VCL.

## Implementado nesta etapa
- capability registry para providers LLM
- model router com preferência por engines locais
- conexão LLM unificada reaproveitando `aillmproviders`
- sample `unified_llm_router_demo`
- novo pacote `openai_a2a` com cliente A2A e servidor stateless para publicar `TAIAgent`
- agentes Lazarus de fonte, build (`lazbuild`), teste e rede
- sample `dev_agents_demo`
- integração do A2A nos instaladores Lazarus Linux/Windows

## Compatibilidade
As APIs existentes foram preservadas. As novas camadas ficam sobre os componentes atuais.

## Validação
Esta PR fica draft até os workflows Lazarus compilarem os pacotes/samples. O ambiente da sessão não possui `fpc/lazbuild`, portanto a validação real deve vir do CI do próprio repositório.