### PR TITLE
feat: adiciona agentes ROS 2 para robótica

### DIFF
--- a/pacote/AI Agent/airosagent.pas
+++ b/pacote/AI Agent/airosagent.pas
@@ -1,0 +1,320 @@
+unit airosagent;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, Math, LResources, aibase, aiprocessrunner;
+
+type
+  { TAIROSAgent
+    Lazarus/FPC wrapper around the ROS 2 command line interface.
+    Read/introspection operations are enabled by default. Operations that can
+    change robot state are blocked until AllowControl=True. }
+  TAIROSAgent = class(TAIBaseComponent)
+  private
+    FRunner: TAIProcessRunner;
+    FROS2Path: string;
+    FWorkingDirectory: string;
+    FTimeoutMs: Integer;
+    FAllowControl: Boolean;
+    function ExecuteROS(const AParams: array of string;
+      ARequiresControl: Boolean = False): Boolean;
+    function GetStdOutText: string;
+    function GetStdErrText: string;
+    function GetExitCode: Integer;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function CheckROS: Boolean;
+    function ListNodes: Boolean;
+    function ListTopics(AWithTypes: Boolean = True): Boolean;
+    function ListServices(AWithTypes: Boolean = True): Boolean;
+    function ListActions: Boolean;
+    function TopicInfo(const ATopic: string): Boolean;
+    function TopicEchoOnce(const ATopic: string): Boolean;
+    function PublishOnce(const ATopic, AMessageType, AYAML: string): Boolean;
+    function CallService(const AService, AServiceType, AYAML: string): Boolean;
+    function GetParam(const ANode, AParamName: string): Boolean;
+    function SetParam(const ANode, AParamName, AValue: string): Boolean;
+    procedure Stop;
+    property StdOutText: string read GetStdOutText;
+    property StdErrText: string read GetStdErrText;
+    property ExitCode: Integer read GetExitCode;
+  published
+    property ROS2Path: string read FROS2Path write FROS2Path;
+    property WorkingDirectory: string read FWorkingDirectory write FWorkingDirectory;
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 30000;
+    property AllowControl: Boolean read FAllowControl write FAllowControl default False;
+  end;
+
+  { TAIRobotAgent
+    High-level differential/mobile robot helper over a TAIROSAgent.
+    Uses geometry_msgs/msg/Twist on CmdVelTopic. }
+  TAIRobotAgent = class(TAIBaseComponent)
+  private
+    FROS: TAIROSAgent;
+    FCmdVelTopic: string;
+    FMaxLinearSpeed: Double;
+    FMaxAngularSpeed: Double;
+    procedure SetROS(AValue: TAIROSAgent);
+    function FloatInvariant(const AValue: Double): string;
+    function TwistYAML(ALinearX, AAngularZ: Double): string;
+  protected
+    procedure Notification(AComponent: TComponent; Operation: TOperation); override;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function Move(ALinearX, AAngularZ: Double): Boolean;
+    function StopRobot: Boolean;
+    function Forward(ASpeed: Double): Boolean;
+    function Backward(ASpeed: Double): Boolean;
+    function RotateLeft(AAngularSpeed: Double): Boolean;
+    function RotateRight(AAngularSpeed: Double): Boolean;
+  published
+    property ROS: TAIROSAgent read FROS write SetROS;
+    property CmdVelTopic: string read FCmdVelTopic write FCmdVelTopic;
+    property MaxLinearSpeed: Double read FMaxLinearSpeed write FMaxLinearSpeed;
+    property MaxAngularSpeed: Double read FMaxAngularSpeed write FMaxAngularSpeed;
+  end;
+
+procedure Register;
+
+implementation
+
+procedure Register;
+begin
+  RegisterComponents('AI Robotics', [TAIROSAgent, TAIRobotAgent]);
+end;
+
+{ TAIROSAgent }
+
+constructor TAIROSAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FROS2Path := 'ros2';
+  FTimeoutMs := 30000;
+  FAllowControl := False;
+  FRunner := TAIProcessRunner.Create(Self);
+end;
+
+function TAIROSAgent.ExecuteROS(const AParams: array of string;
+  ARequiresControl: Boolean): Boolean;
+begin
+  ClearError;
+  if ARequiresControl and (not FAllowControl) then
+  begin
+    SetError('AllowControl=False. Comando de controle ROS bloqueado.');
+    Exit(False);
+  end;
+
+  FRunner.Executable := FROS2Path;
+  FRunner.WorkingDirectory := FWorkingDirectory;
+  FRunner.TimeoutMs := FTimeoutMs;
+  Result := FRunner.Execute(AParams);
+  FLastSuccess := Result;
+  FLastResult := FRunner.StdOutText;
+  if not Result then
+    SetError(FRunner.LastError);
+end;
+
+function TAIROSAgent.GetStdOutText: string;
+begin
+  Result := FRunner.StdOutText;
+end;
+
+function TAIROSAgent.GetStdErrText: string;
+begin
+  Result := FRunner.StdErrText;
+end;
+
+function TAIROSAgent.GetExitCode: Integer;
+begin
+  Result := FRunner.LastExitCode;
+end;
+
+function TAIROSAgent.CheckROS: Boolean;
+begin
+  Result := ExecuteROS(['--help']);
+end;
+
+function TAIROSAgent.ListNodes: Boolean;
+begin
+  Result := ExecuteROS(['node', 'list']);
+end;
+
+function TAIROSAgent.ListTopics(AWithTypes: Boolean): Boolean;
+begin
+  if AWithTypes then
+    Result := ExecuteROS(['topic', 'list', '-t'])
+  else
+    Result := ExecuteROS(['topic', 'list']);
+end;
+
+function TAIROSAgent.ListServices(AWithTypes: Boolean): Boolean;
+begin
+  if AWithTypes then
+    Result := ExecuteROS(['service', 'list', '-t'])
+  else
+    Result := ExecuteROS(['service', 'list']);
+end;
+
+function TAIROSAgent.ListActions: Boolean;
+begin
+  Result := ExecuteROS(['action', 'list', '-t']);
+end;
+
+function TAIROSAgent.TopicInfo(const ATopic: string): Boolean;
+begin
+  if Trim(ATopic) = '' then
+  begin
+    SetError('Topic vazio.');
+    Exit(False);
+  end;
+  Result := ExecuteROS(['topic', 'info', ATopic]);
+end;
+
+function TAIROSAgent.TopicEchoOnce(const ATopic: string): Boolean;
+begin
+  if Trim(ATopic) = '' then
+  begin
+    SetError('Topic vazio.');
+    Exit(False);
+  end;
+  Result := ExecuteROS(['topic', 'echo', '--once', ATopic]);
+end;
+
+function TAIROSAgent.PublishOnce(const ATopic, AMessageType, AYAML: string): Boolean;
+begin
+  if (Trim(ATopic) = '') or (Trim(AMessageType) = '') then
+  begin
+    SetError('Topic e MessageType sao obrigatorios.');
+    Exit(False);
+  end;
+  Result := ExecuteROS(['topic', 'pub', '--once', ATopic, AMessageType, AYAML], True);
+end;
+
+function TAIROSAgent.CallService(const AService, AServiceType, AYAML: string): Boolean;
+begin
+  if (Trim(AService) = '') or (Trim(AServiceType) = '') then
+  begin
+    SetError('Service e ServiceType sao obrigatorios.');
+    Exit(False);
+  end;
+  Result := ExecuteROS(['service', 'call', AService, AServiceType, AYAML], True);
+end;
+
+function TAIROSAgent.GetParam(const ANode, AParamName: string): Boolean;
+begin
+  if (Trim(ANode) = '') or (Trim(AParamName) = '') then
+  begin
+    SetError('Node e ParamName sao obrigatorios.');
+    Exit(False);
+  end;
+  Result := ExecuteROS(['param', 'get', ANode, AParamName]);
+end;
+
+function TAIROSAgent.SetParam(const ANode, AParamName, AValue: string): Boolean;
+begin
+  if (Trim(ANode) = '') or (Trim(AParamName) = '') then
+  begin
+    SetError('Node e ParamName sao obrigatorios.');
+    Exit(False);
+  end;
+  Result := ExecuteROS(['param', 'set', ANode, AParamName, AValue], True);
+end;
+
+procedure TAIROSAgent.Stop;
+begin
+  FRunner.Stop;
+end;
+
+{ TAIRobotAgent }
+
+constructor TAIRobotAgent.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FCategory := ccAction;
+  FCmdVelTopic := '/cmd_vel';
+  FMaxLinearSpeed := 1.0;
+  FMaxAngularSpeed := 2.0;
+end;
+
+procedure TAIRobotAgent.SetROS(AValue: TAIROSAgent);
+begin
+  if FROS = AValue then Exit;
+  if Assigned(FROS) then FROS.RemoveFreeNotification(Self);
+  FROS := AValue;
+  if Assigned(FROS) then FROS.FreeNotification(Self);
+end;
+
+procedure TAIRobotAgent.Notification(AComponent: TComponent; Operation: TOperation);
+begin
+  inherited Notification(AComponent, Operation);
+  if (Operation = opRemove) and (AComponent = FROS) then
+    FROS := nil;
+end;
+
+function TAIRobotAgent.FloatInvariant(const AValue: Double): string;
+var
+  FS: TFormatSettings;
+begin
+  FS := DefaultFormatSettings;
+  FS.DecimalSeparator := '.';
+  Result := FloatToStr(AValue, FS);
+end;
+
+function TAIRobotAgent.TwistYAML(ALinearX, AAngularZ: Double): string;
+begin
+  Result := '{linear: {x: ' + FloatInvariant(ALinearX) +
+    ', y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: ' +
+    FloatInvariant(AAngularZ) + '}}';
+end;
+
+function TAIRobotAgent.Move(ALinearX, AAngularZ: Double): Boolean;
+begin
+  ClearError;
+  if FROS = nil then
+  begin
+    SetError('ROS nao configurado.');
+    Exit(False);
+  end;
+
+  if FMaxLinearSpeed < 0 then FMaxLinearSpeed := Abs(FMaxLinearSpeed);
+  if FMaxAngularSpeed < 0 then FMaxAngularSpeed := Abs(FMaxAngularSpeed);
+  ALinearX := EnsureRange(ALinearX, -FMaxLinearSpeed, FMaxLinearSpeed);
+  AAngularZ := EnsureRange(AAngularZ, -FMaxAngularSpeed, FMaxAngularSpeed);
+
+  Result := FROS.PublishOnce(FCmdVelTopic, 'geometry_msgs/msg/Twist',
+    TwistYAML(ALinearX, AAngularZ));
+  FLastSuccess := Result;
+  FLastResult := FROS.LastResult;
+  if not Result then SetError(FROS.LastError);
+end;
+
+function TAIRobotAgent.StopRobot: Boolean;
+begin
+  Result := Move(0.0, 0.0);
+end;
+
+function TAIRobotAgent.Forward(ASpeed: Double): Boolean;
+begin
+  Result := Move(Abs(ASpeed), 0.0);
+end;
+
+function TAIRobotAgent.Backward(ASpeed: Double): Boolean;
+begin
+  Result := Move(-Abs(ASpeed), 0.0);
+end;
+
+function TAIRobotAgent.RotateLeft(AAngularSpeed: Double): Boolean;
+begin
+  Result := Move(0.0, Abs(AAngularSpeed));
+end;
+
+function TAIRobotAgent.RotateRight(AAngularSpeed: Double): Boolean;
+begin
+  Result := Move(0.0, -Abs(AAngularSpeed));
+end;
+
+end.

--- a/pacote/packages/openai_agent.lpk
+++ b/pacote/packages/openai_agent.lpk
@@ -36,6 +36,7 @@
       <Item><Filename Value="..\AI Agent\aidevagents.pas"/><HasRegisterProc Value="True"/><UnitName Value="aidevagents"/></Item>
       <Item><Filename Value="..\AI Agent\aiserviceagents.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiserviceagents"/></Item>
       <Item><Filename Value="..\AI Agent\aicommonserviceagents.pas"/><HasRegisterProc Value="True"/><UnitName Value="aicommonserviceagents"/></Item>
+      <Item><Filename Value="..\AI Agent\airosagent.pas"/><HasRegisterProc Value="True"/><UnitName Value="airosagent"/></Item>
     </Files>
     <RequiredPkgs>
       <Item><PackageName Value="GLScene_DesignTime"/></Item>

--- a/pacote/samples/AI Agent/ros_robotics_demo/README.md
+++ b/pacote/samples/AI Agent/ros_robotics_demo/README.md
@@ -1,0 +1,50 @@
+# ROS Robotics Agent Demo
+
+Sample Lazarus/Free Pascal for `TAIROSAgent` and `TAIRobotAgent`.
+
+## Requirements
+
+- Lazarus / Free Pascal
+- package `openai_agent`
+- ROS 2 installed and the `ros2` CLI available in PATH
+- for robot movement, a ROS 2 robot or simulator exposing a `geometry_msgs/msg/Twist` velocity topic (default `/cmd_vel`)
+
+## Safety
+
+`TAIROSAgent.AllowControl` defaults to `False`.
+
+Read/introspection operations such as listing nodes, topics and services are allowed. Publishing topics, calling services and changing parameters are blocked until control is explicitly enabled.
+
+```pascal
+ROS.AllowControl := True;
+Robot.CmdVelTopic := '/cmd_vel';
+Robot.Forward(0.10);
+Robot.StopRobot;
+```
+
+Configure speed limits and verify the robot/simulator before enabling control.
+
+## Main API
+
+`TAIROSAgent`:
+
+- `CheckROS`
+- `ListNodes`
+- `ListTopics`
+- `ListServices`
+- `ListActions`
+- `TopicInfo`
+- `TopicEchoOnce`
+- `PublishOnce`
+- `CallService`
+- `GetParam`
+- `SetParam`
+
+`TAIRobotAgent`:
+
+- `Move`
+- `StopRobot`
+- `Forward`
+- `Backward`
+- `RotateLeft`
+- `RotateRight`

--- a/pacote/samples/AI Agent/ros_robotics_demo/ros_robotics_demo.lpi
+++ b/pacote/samples/AI Agent/ros_robotics_demo/ros_robotics_demo.lpi
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="ros_robotics_demo"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes><Item Name="Default" Default="True"/></BuildModes>
+    <RequiredPackages>
+      <Item><PackageName Value="openai_agent"/></Item>
+    </RequiredPackages>
+    <Units>
+      <Unit><Filename Value="ros_robotics_demo.lpr"/><IsPartOfProject Value="True"/></Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target><Filename Value="ros_robotics_demo"/></Target>
+    <SearchPaths><UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/></SearchPaths>
+    <Parsing><SyntaxOptions><UseAnsiStrings Value="True"/></SyntaxOptions></Parsing>
+  </CompilerOptions>
+</CONFIG>

--- a/pacote/samples/AI Agent/ros_robotics_demo/ros_robotics_demo.lpr
+++ b/pacote/samples/AI Agent/ros_robotics_demo/ros_robotics_demo.lpr
@@ -1,0 +1,46 @@
+program ros_robotics_demo;
+
+{$mode objfpc}{$H+}
+
+uses
+  Classes, SysUtils, airosagent;
+
+var
+  ROS: TAIROSAgent;
+  Robot: TAIRobotAgent;
+begin
+  ROS := TAIROSAgent.Create(nil);
+  Robot := TAIRobotAgent.Create(nil);
+  try
+    Robot.ROS := ROS;
+
+    Writeln('ROS 2 robotics demo');
+    Writeln('Control is blocked by default: AllowControl=False');
+
+    if ROS.CheckROS then
+    begin
+      Writeln('ROS 2 CLI detected.');
+      if ROS.ListNodes then
+        Writeln('Nodes:' + LineEnding + ROS.StdOutText)
+      else
+        Writeln('Node list error: ' + ROS.LastError);
+
+      if ROS.ListTopics(True) then
+        Writeln('Topics:' + LineEnding + ROS.StdOutText)
+      else
+        Writeln('Topic list error: ' + ROS.LastError);
+    end
+    else
+      Writeln('ROS 2 CLI not available: ' + ROS.LastError);
+
+    { To control a configured robot explicitly enable:
+        ROS.AllowControl := True;
+        Robot.CmdVelTopic := '/cmd_vel';
+        Robot.Forward(0.10);
+        Robot.StopRobot;
+      Keep disabled unless the robot/simulator and safety limits are configured. }
+  finally
+    Robot.Free;
+    ROS.Free;
+  end;
+end.


### PR DESCRIPTION
## Objetivo
Adicionar integração de robótica ao framework Lazarus/FPC usando ROS 2 sem dependência de binding C/Pascal específico.

## Implementado
- `TAIROSAgent` usando `ros2` CLI via `TAIProcessRunner`
- introspecção de nodes, topics, services e actions
- leitura de topic e parâmetros
- publicação de topic, chamada de service e alteração de parâmetro protegidas por `AllowControl=False`
- `TAIRobotAgent` para controle móvel via `geometry_msgs/msg/Twist`
- limites configuráveis de velocidade linear/angular
- comandos `Move`, `StopRobot`, `Forward`, `Backward`, `RotateLeft` e `RotateRight`
- registro na paleta `AI Robotics`
- sample `ros_robotics_demo`

## Segurança
Controle físico fica bloqueado por padrão. O usuário precisa habilitar explicitamente `AllowControl=True` e configurar o tópico/limites antes de atuar no robô.

## Compatibilidade
Somente Lazarus/Free Pascal, seguindo o escopo atual do projeto.