### PR TITLE
add reusable source correction, build and test agent actions

### DIFF
--- a/.github/workflows/fgx-core.yml
+++ b/.github/workflows/fgx-core.yml
@@ -27,15 +27,12 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y fpc
 
-      - name: Instalar Free Pascal (Windows)
+      - name: Instalar Lazarus e Free Pascal completos (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          choco install freepascal -y
-          $fpc = Get-ChildItem -Path 'C:\tools' -Recurse -Filter fpc.exe -ErrorAction SilentlyContinue | Select-Object -First 1
-          if ($null -eq $fpc) { throw 'fpc.exe não encontrado após instalação do Free Pascal.' }
-          $fpc.Directory.FullName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          Write-Host "FPC encontrado em $($fpc.FullName)"
+        uses: gcarreno/setup-lazarus@v3.4.1
+        with:
+          lazarus-version: "4.4"
+          with-cache: false
 
       # -Sew: warning vira erro. Nada de "compila com avisos".
       - name: Compilar o nucleo

--- a/.github/workflows/fgx-core.yml
+++ b/.github/workflows/fgx-core.yml
@@ -29,9 +29,13 @@ jobs:
 
       - name: Instalar Free Pascal (Windows)
         if: runner.os == 'Windows'
+        shell: pwsh
         run: |
           choco install freepascal -y
-          echo "C:\tools\fpc\bin\i386-win32" >> $GITHUB_PATH
+          $fpc = Get-ChildItem -Path 'C:\tools' -Recurse -Filter fpc.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($null -eq $fpc) { throw 'fpc.exe não encontrado após instalação do Free Pascal.' }
+          $fpc.Directory.FullName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Write-Host "FPC encontrado em $($fpc.FullName)"
 
       # -Sew: warning vira erro. Nada de "compila com avisos".
       - name: Compilar o nucleo
@@ -53,14 +57,11 @@ jobs:
         working-directory: ${{ env.FGX_DIR }}
         run: ./build/fgx_graph_tests ../../../..
 
-      # A fixture inclui um .lpk deliberadamente corrompido: deve virar 'partial'
-      # e o pipeline deve seguir. Esperado: 13 nos, 15 arestas, PASS.
       - name: Rodar contra a fixture
         shell: bash
         working-directory: ${{ env.FGX_DIR }}
         run: ./build/fgxcli fixtures/repo build/out
 
-      # E1: o grafo real da suite. Exit != 0 se a validacao falhar.
       - name: Rodar contra o repositorio real (E1)
         shell: bash
         working-directory: ${{ env.FGX_DIR }}

--- a/DOC/components/TAISourceActions/README.md
+++ b/DOC/components/TAISourceActions/README.md
@@ -1,0 +1,24 @@
+# Developer Source Actions
+
+Reusable Lazarus/FPC actions for `TAIActionExecutor`.
+
+## Components
+
+- `TAISourceReadAction` — reads a workspace file.
+- `TAISourceReplaceAction` — replaces an exact source fragment with unique-match protection and atomic temporary backup.
+- `TAIProjectBuildAction` — invokes a trusted builder such as `lazbuild` for a project inside the workspace.
+- `TAITrustedProjectTestAction` — invokes a trusted test runner configured by the host application.
+
+## Security model
+
+File paths supplied by the LLM are restricted to `WorkspaceRoot`. Path traversal outside that root is rejected. Builder and test executables are configured by the host application, not chosen by the LLM. `ASimulate=True` performs validation without changing files or running tools.
+
+## Typical flow
+
+1. Register the actions in `TAIActionExecutor`.
+2. Let the agent produce prepared JSON actions.
+3. Execute via `ExecutePreparedActionsReal`.
+4. Inspect `LastOutput`/`LastError` and the executor MemoryMap.
+5. Let the IDE show the resulting diff and diagnostics.
+
+The host IDE remains responsible for user approval policy and UI presentation.

--- a/pacote/AI Agent/aiagent_sourceactions.pas
+++ b/pacote/AI Agent/aiagent_sourceactions.pas
@@ -1,0 +1,286 @@
+unit aiagent_sourceactions;
+
+{$mode objfpc}{$H+}
+{$codepage utf8}
+
+interface
+
+uses
+  Classes, SysUtils, Process, aiagent_actions, LResources;
+
+type
+  TAIDeveloperWorkspaceAction = class(TAICustomAgentAction)
+  private
+    FWorkspaceRoot: string;
+    FLastOutput: string;
+    function NormalizeRoot: string;
+  protected
+    function ResolveWorkspacePath(const APath: string; out AFullPath,
+      AError: string): Boolean;
+    procedure SetOutput(const AValue: string);
+  public
+    property LastOutput: string read FLastOutput;
+  published
+    property WorkspaceRoot: string read FWorkspaceRoot write FWorkspaceRoot;
+  end;
+
+  TAISourceReadAction = class(TAIDeveloperWorkspaceAction)
+  public
+    constructor Create(AOwner: TComponent); override;
+    function RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean; override;
+  end;
+
+  TAISourceReplaceAction = class(TAIDeveloperWorkspaceAction)
+  private
+    FRequireUniqueMatch: Boolean;
+    function CountOccurrences(const AText, ANeedle: string): Integer;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean; override;
+  published
+    property RequireUniqueMatch: Boolean read FRequireUniqueMatch
+      write FRequireUniqueMatch default True;
+  end;
+
+  TAIProjectBuildAction = class(TAIDeveloperWorkspaceAction)
+  private
+    FBuilderExecutable: string;
+    FProjectFile: string;
+    FBuildArguments: string;
+    FTimeoutMs: Integer;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean; override;
+  published
+    property BuilderExecutable: string read FBuilderExecutable write FBuilderExecutable;
+    property ProjectFile: string read FProjectFile write FProjectFile;
+    property BuildArguments: string read FBuildArguments write FBuildArguments;
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 120000;
+  end;
+
+  TAIProjectTestAction = class(TAIDeveloperWorkspaceAction)
+  private
+    FTestExecutable: string;
+    FTestArguments: string;
+    FTimeoutMs: Integer;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean; override;
+  published
+    property TestExecutable: string read FTestExecutable write FTestExecutable;
+    property TestArguments: string read FTestArguments write FTestArguments;
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 120000;
+  end;
+
+procedure Register;
+
+implementation
+
+function ParamValue(AParams: TStrings; const AName: string): string;
+begin
+  Result := '';
+  if Assigned(AParams) then Result := AParams.Values[AName];
+end;
+
+procedure SplitArguments(const AText: string; AArgs: TStrings);
+var
+  I: Integer;
+  C: Char;
+  Token: string;
+  Quoted: Boolean;
+begin
+  AArgs.Clear;
+  Token := '';
+  Quoted := False;
+  for I := 1 to Length(AText) do
+  begin
+    C := AText[I];
+    if C = '"' then Quoted := not Quoted
+    else if (C in [' ', #9]) and not Quoted then
+    begin
+      if Token <> '' then begin AArgs.Add(Token); Token := ''; end;
+    end
+    else Token := Token + C;
+  end;
+  if Token <> '' then AArgs.Add(Token);
+end;
+
+function ReadProcessOutput(AProcess: TProcess): string;
+var
+  Buffer: array[0..4095] of Byte;
+  N: LongInt;
+  S: RawByteString;
+begin
+  Result := '';
+  while AProcess.Output.NumBytesAvailable > 0 do
+  begin
+    N := AProcess.Output.Read(Buffer, SizeOf(Buffer));
+    if N <= 0 then Break;
+    SetString(S, PAnsiChar(@Buffer[0]), N);
+    Result := Result + string(S);
+  end;
+end;
+
+function RunConfiguredProcess(const AExecutable: string; AParams: TStrings;
+  const AWorkingDir: string; ATimeoutMs: Integer; out AOutput,
+  AError: string): Boolean;
+var
+  P: TProcess;
+  StartTick: QWord;
+  I: Integer;
+begin
+  Result := False;
+  AOutput := '';
+  AError := '';
+  if Trim(AExecutable) = '' then begin AError := 'Executável não configurado.'; Exit; end;
+  P := TProcess.Create(nil);
+  try
+    P.Executable := AExecutable;
+    P.CurrentDirectory := AWorkingDir;
+    P.Options := [poUsePipes, poStderrToOutPut];
+    for I := 0 to AParams.Count - 1 do P.Parameters.Add(AParams[I]);
+    try P.Execute; except on E: Exception do begin AError := E.Message; Exit(False); end; end;
+    StartTick := GetTickCount64;
+    while P.Running do
+    begin
+      AOutput := AOutput + ReadProcessOutput(P);
+      if (ATimeoutMs > 0) and (GetTickCount64 - StartTick > QWord(ATimeoutMs)) then
+      begin P.Terminate(1); AError := 'Tempo limite excedido ao executar ' + AExecutable; Exit(False); end;
+      Sleep(10);
+    end;
+    AOutput := AOutput + ReadProcessOutput(P);
+    Result := P.ExitStatus = 0;
+    if not Result then AError := 'Processo terminou com código ' + IntToStr(P.ExitStatus) + '.';
+  finally P.Free; end;
+end;
+
+function TAIDeveloperWorkspaceAction.NormalizeRoot: string;
+begin
+  Result := ExpandFileName(Trim(FWorkspaceRoot));
+  if Result <> '' then Result := IncludeTrailingPathDelimiter(Result);
+end;
+
+function TAIDeveloperWorkspaceAction.ResolveWorkspacePath(const APath: string;
+  out AFullPath, AError: string): Boolean;
+var
+  Root, Candidate, CandidateDir: string;
+begin
+  Result := False;
+  AError := '';
+  AFullPath := '';
+  Root := NormalizeRoot;
+  if (Root = '') or not DirectoryExists(Root) then begin AError := 'WorkspaceRoot inválido: ' + FWorkspaceRoot; Exit; end;
+  if Trim(APath) = '' then begin AError := 'Caminho não informado.'; Exit; end;
+  if FilenameIsAbsolute(APath) then Candidate := ExpandFileName(APath)
+  else Candidate := ExpandFileName(Root + APath);
+  CandidateDir := IncludeTrailingPathDelimiter(ExtractFileDir(Candidate));
+  if Pos(LowerCase(Root), LowerCase(CandidateDir)) <> 1 then
+  begin AError := 'Acesso bloqueado fora do WorkspaceRoot: ' + Candidate; Exit; end;
+  AFullPath := Candidate;
+  Result := True;
+end;
+
+procedure TAIDeveloperWorkspaceAction.SetOutput(const AValue: string);
+begin FLastOutput := AValue; end;
+
+constructor TAISourceReadAction.Create(AOwner: TComponent);
+begin inherited Create(AOwner); ActionName := 'read_source'; end;
+
+function TAISourceReadAction.RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean;
+var FileName, ErrorText: string; S: TStringList;
+begin
+  Result := False; SetOutput('');
+  if not ResolveWorkspacePath(ParamValue(AParams, 'file'), FileName, ErrorText) then begin SetError(ErrorText); Exit; end;
+  if not FileExists(FileName) then begin SetError('Arquivo não encontrado: ' + FileName); Exit; end;
+  if ASimulate then begin SetOutput('SIMULATE read_source ' + FileName); Exit(True); end;
+  S := TStringList.Create;
+  try
+    try S.LoadFromFile(FileName); except on E: Exception do begin SetError(E.Message); Exit(False); end; end;
+    SetOutput(S.Text); Result := True;
+  finally S.Free; end;
+end;
+
+constructor TAISourceReplaceAction.Create(AOwner: TComponent);
+begin inherited Create(AOwner); ActionName := 'replace_source'; FRequireUniqueMatch := True; end;
+
+function TAISourceReplaceAction.CountOccurrences(const AText, ANeedle: string): Integer;
+var P, Offset: Integer;
+begin
+  Result := 0; if ANeedle = '' then Exit; Offset := 1;
+  repeat
+    P := Pos(ANeedle, Copy(AText, Offset, MaxInt));
+    if P > 0 then begin Inc(Result); Inc(Offset, P - 1 + Length(ANeedle)); end;
+  until P = 0;
+end;
+
+function TAISourceReplaceAction.RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean;
+var FileName, ErrorText, OldText, NewText, Content, TempFile, BackupFile: string; S: TStringList; Matches: Integer;
+begin
+  Result := False; SetOutput('');
+  if not ResolveWorkspacePath(ParamValue(AParams, 'file'), FileName, ErrorText) then begin SetError(ErrorText); Exit; end;
+  OldText := ParamValue(AParams, 'old_text'); NewText := ParamValue(AParams, 'new_text');
+  if OldText = '' then begin SetError('old_text não informado.'); Exit; end;
+  if not FileExists(FileName) then begin SetError('Arquivo não encontrado: ' + FileName); Exit; end;
+  S := TStringList.Create;
+  try
+    try S.LoadFromFile(FileName); except on E: Exception do begin SetError(E.Message); Exit(False); end; end;
+    Content := S.Text; Matches := CountOccurrences(Content, OldText);
+    if Matches = 0 then begin SetError('Trecho old_text não encontrado.'); Exit; end;
+    if FRequireUniqueMatch and (Matches <> 1) then begin SetError('Trecho ambíguo: ' + IntToStr(Matches) + ' ocorrências.'); Exit; end;
+    Content := StringReplace(Content, OldText, NewText, [rfReplaceAll]);
+    if ASimulate then begin SetOutput('SIMULATE replace_source ' + FileName); Exit(True); end;
+    TempFile := FileName + '.aiagent.tmp'; BackupFile := FileName + '.aiagent.bak'; S.Text := Content;
+    try
+      S.SaveToFile(TempFile);
+      if FileExists(BackupFile) then DeleteFile(BackupFile);
+      if not RenameFile(FileName, BackupFile) then raise Exception.Create('Não foi possível criar backup temporário.');
+      if not RenameFile(TempFile, FileName) then begin RenameFile(BackupFile, FileName); raise Exception.Create('Não foi possível substituir o fonte.'); end;
+      DeleteFile(BackupFile);
+    except on E: Exception do begin if FileExists(TempFile) then DeleteFile(TempFile); SetError(E.Message); Exit(False); end; end;
+    SetOutput('Fonte atualizado: ' + FileName); Result := True;
+  finally S.Free; end;
+end;
+
+constructor TAIProjectBuildAction.Create(AOwner: TComponent);
+begin inherited Create(AOwner); ActionName := 'build_project'; FBuilderExecutable := 'lazbuild'; FTimeoutMs := 120000; end;
+
+function TAIProjectBuildAction.RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean;
+var ProjectPath, ErrorText, OutputText, ProjectParam: string; Args: TStringList;
+begin
+  Result := False; SetOutput(''); ProjectParam := ParamValue(AParams, 'project'); if ProjectParam = '' then ProjectParam := FProjectFile;
+  if not ResolveWorkspacePath(ProjectParam, ProjectPath, ErrorText) then begin SetError(ErrorText); Exit; end;
+  if not FileExists(ProjectPath) then begin SetError('Projeto não encontrado: ' + ProjectPath); Exit; end;
+  Args := TStringList.Create;
+  try
+    SplitArguments(FBuildArguments, Args); Args.Add(ProjectPath);
+    if ASimulate then begin SetOutput('SIMULATE build_project ' + ProjectPath); Exit(True); end;
+    Result := RunConfiguredProcess(FBuilderExecutable, Args, ExtractFileDir(ProjectPath), FTimeoutMs, OutputText, ErrorText);
+    SetOutput(OutputText); if not Result then SetError(ErrorText + LineEnding + OutputText);
+  finally Args.Free; end;
+end;
+
+constructor TAIProjectTestAction.Create(AOwner: TComponent);
+begin inherited Create(AOwner); ActionName := 'run_tests'; FTimeoutMs := 120000; end;
+
+function TAIProjectTestAction.RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean;
+var ExecutablePath, ErrorText, OutputText: string; Args: TStringList;
+begin
+  Result := False; SetOutput('');
+  if not ResolveWorkspacePath(FTestExecutable, ExecutablePath, ErrorText) then begin SetError(ErrorText); Exit; end;
+  if not FileExists(ExecutablePath) then begin SetError('Teste não encontrado: ' + ExecutablePath); Exit; end;
+  Args := TStringList.Create;
+  try
+    SplitArguments(FTestArguments, Args);
+    if ASimulate then begin SetOutput('SIMULATE run_tests ' + ExecutablePath); Exit(True); end;
+    Result := RunConfiguredProcess(ExecutablePath, Args, ExtractFileDir(ExecutablePath), FTimeoutMs, OutputText, ErrorText);
+    SetOutput(OutputText); if not Result then SetError(ErrorText + LineEnding + OutputText);
+  finally Args.Free; end;
+end;
+
+procedure Register;
+begin
+  RegisterComponents('AI Agents', [TAISourceReadAction, TAISourceReplaceAction,
+    TAIProjectBuildAction, TAIProjectTestAction]);
+end;
+
+end.

--- a/pacote/AI Agent/aiagent_sourceactions.pas
+++ b/pacote/AI Agent/aiagent_sourceactions.pas
@@ -58,20 +58,6 @@ type
     property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 120000;
   end;
 
-  TAIProjectTestAction = class(TAIDeveloperWorkspaceAction)
-  private
-    FTestExecutable: string;
-    FTestArguments: string;
-    FTimeoutMs: Integer;
-  public
-    constructor Create(AOwner: TComponent); override;
-    function RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean; override;
-  published
-    property TestExecutable: string read FTestExecutable write FTestExecutable;
-    property TestArguments: string read FTestArguments write FTestArguments;
-    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 120000;
-  end;
-
 procedure Register;
 
 implementation
@@ -98,7 +84,11 @@ begin
     if C = '"' then Quoted := not Quoted
     else if (C in [' ', #9]) and not Quoted then
     begin
-      if Token <> '' then begin AArgs.Add(Token); Token := ''; end;
+      if Token <> '' then
+      begin
+        AArgs.Add(Token);
+        Token := '';
+      end;
     end
     else Token := Token + C;
   end;
@@ -132,26 +122,46 @@ begin
   Result := False;
   AOutput := '';
   AError := '';
-  if Trim(AExecutable) = '' then begin AError := 'Executável não configurado.'; Exit; end;
+  if Trim(AExecutable) = '' then
+  begin
+    AError := 'Executável não configurado.';
+    Exit;
+  end;
   P := TProcess.Create(nil);
   try
     P.Executable := AExecutable;
     P.CurrentDirectory := AWorkingDir;
     P.Options := [poUsePipes, poStderrToOutPut];
     for I := 0 to AParams.Count - 1 do P.Parameters.Add(AParams[I]);
-    try P.Execute; except on E: Exception do begin AError := E.Message; Exit(False); end; end;
+    try
+      P.Execute;
+    except
+      on E: Exception do
+      begin
+        AError := E.Message;
+        Exit(False);
+      end;
+    end;
     StartTick := GetTickCount64;
     while P.Running do
     begin
       AOutput := AOutput + ReadProcessOutput(P);
-      if (ATimeoutMs > 0) and (GetTickCount64 - StartTick > QWord(ATimeoutMs)) then
-      begin P.Terminate(1); AError := 'Tempo limite excedido ao executar ' + AExecutable; Exit(False); end;
+      if (ATimeoutMs > 0) and
+         (GetTickCount64 - StartTick > QWord(ATimeoutMs)) then
+      begin
+        P.Terminate(1);
+        AError := 'Tempo limite excedido ao executar ' + AExecutable;
+        Exit(False);
+      end;
       Sleep(10);
     end;
     AOutput := AOutput + ReadProcessOutput(P);
     Result := P.ExitStatus = 0;
-    if not Result then AError := 'Processo terminou com código ' + IntToStr(P.ExitStatus) + '.';
-  finally P.Free; end;
+    if not Result then
+      AError := 'Processo terminou com código ' + IntToStr(P.ExitStatus) + '.';
+  finally
+    P.Free;
+  end;
 end;
 
 function TAIDeveloperWorkspaceAction.NormalizeRoot: string;
@@ -169,118 +179,242 @@ begin
   AError := '';
   AFullPath := '';
   Root := NormalizeRoot;
-  if (Root = '') or not DirectoryExists(Root) then begin AError := 'WorkspaceRoot inválido: ' + FWorkspaceRoot; Exit; end;
-  if Trim(APath) = '' then begin AError := 'Caminho não informado.'; Exit; end;
+  if (Root = '') or not DirectoryExists(Root) then
+  begin
+    AError := 'WorkspaceRoot inválido: ' + FWorkspaceRoot;
+    Exit;
+  end;
+  if Trim(APath) = '' then
+  begin
+    AError := 'Caminho não informado.';
+    Exit;
+  end;
   if FilenameIsAbsolute(APath) then Candidate := ExpandFileName(APath)
   else Candidate := ExpandFileName(Root + APath);
   CandidateDir := IncludeTrailingPathDelimiter(ExtractFileDir(Candidate));
   if Pos(LowerCase(Root), LowerCase(CandidateDir)) <> 1 then
-  begin AError := 'Acesso bloqueado fora do WorkspaceRoot: ' + Candidate; Exit; end;
+  begin
+    AError := 'Acesso bloqueado fora do WorkspaceRoot: ' + Candidate;
+    Exit;
+  end;
   AFullPath := Candidate;
   Result := True;
 end;
 
 procedure TAIDeveloperWorkspaceAction.SetOutput(const AValue: string);
-begin FLastOutput := AValue; end;
+begin
+  FLastOutput := AValue;
+end;
 
 constructor TAISourceReadAction.Create(AOwner: TComponent);
-begin inherited Create(AOwner); ActionName := 'read_source'; end;
-
-function TAISourceReadAction.RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean;
-var FileName, ErrorText: string; S: TStringList;
 begin
-  Result := False; SetOutput('');
-  if not ResolveWorkspacePath(ParamValue(AParams, 'file'), FileName, ErrorText) then begin SetError(ErrorText); Exit; end;
-  if not FileExists(FileName) then begin SetError('Arquivo não encontrado: ' + FileName); Exit; end;
-  if ASimulate then begin SetOutput('SIMULATE read_source ' + FileName); Exit(True); end;
+  inherited Create(AOwner);
+  ActionName := 'read_source';
+end;
+
+function TAISourceReadAction.RunAction(const AParams: TStrings;
+  ASimulate: Boolean): Boolean;
+var
+  FileName, ErrorText: string;
+  S: TStringList;
+begin
+  Result := False;
+  SetOutput('');
+  if not ResolveWorkspacePath(ParamValue(AParams, 'file'), FileName,
+    ErrorText) then
+  begin
+    SetError(ErrorText);
+    Exit;
+  end;
+  if not FileExists(FileName) then
+  begin
+    SetError('Arquivo não encontrado: ' + FileName);
+    Exit;
+  end;
+  if ASimulate then
+  begin
+    SetOutput('SIMULATE read_source ' + FileName);
+    Exit(True);
+  end;
   S := TStringList.Create;
   try
-    try S.LoadFromFile(FileName); except on E: Exception do begin SetError(E.Message); Exit(False); end; end;
-    SetOutput(S.Text); Result := True;
-  finally S.Free; end;
+    try
+      S.LoadFromFile(FileName);
+    except
+      on E: Exception do
+      begin
+        SetError(E.Message);
+        Exit(False);
+      end;
+    end;
+    SetOutput(S.Text);
+    Result := True;
+  finally
+    S.Free;
+  end;
 end;
 
 constructor TAISourceReplaceAction.Create(AOwner: TComponent);
-begin inherited Create(AOwner); ActionName := 'replace_source'; FRequireUniqueMatch := True; end;
-
-function TAISourceReplaceAction.CountOccurrences(const AText, ANeedle: string): Integer;
-var P, Offset: Integer;
 begin
-  Result := 0; if ANeedle = '' then Exit; Offset := 1;
+  inherited Create(AOwner);
+  ActionName := 'replace_source';
+  FRequireUniqueMatch := True;
+end;
+
+function TAISourceReplaceAction.CountOccurrences(const AText,
+  ANeedle: string): Integer;
+var
+  P, Offset: Integer;
+begin
+  Result := 0;
+  if ANeedle = '' then Exit;
+  Offset := 1;
   repeat
     P := Pos(ANeedle, Copy(AText, Offset, MaxInt));
-    if P > 0 then begin Inc(Result); Inc(Offset, P - 1 + Length(ANeedle)); end;
+    if P > 0 then
+    begin
+      Inc(Result);
+      Inc(Offset, P - 1 + Length(ANeedle));
+    end;
   until P = 0;
 end;
 
-function TAISourceReplaceAction.RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean;
-var FileName, ErrorText, OldText, NewText, Content, TempFile, BackupFile: string; S: TStringList; Matches: Integer;
+function TAISourceReplaceAction.RunAction(const AParams: TStrings;
+  ASimulate: Boolean): Boolean;
+var
+  FileName, ErrorText, OldText, NewText, Content, TempFile,
+  BackupFile: string;
+  S: TStringList;
+  Matches: Integer;
 begin
-  Result := False; SetOutput('');
-  if not ResolveWorkspacePath(ParamValue(AParams, 'file'), FileName, ErrorText) then begin SetError(ErrorText); Exit; end;
-  OldText := ParamValue(AParams, 'old_text'); NewText := ParamValue(AParams, 'new_text');
-  if OldText = '' then begin SetError('old_text não informado.'); Exit; end;
-  if not FileExists(FileName) then begin SetError('Arquivo não encontrado: ' + FileName); Exit; end;
+  Result := False;
+  SetOutput('');
+  if not ResolveWorkspacePath(ParamValue(AParams, 'file'), FileName,
+    ErrorText) then
+  begin
+    SetError(ErrorText);
+    Exit;
+  end;
+  OldText := ParamValue(AParams, 'old_text');
+  NewText := ParamValue(AParams, 'new_text');
+  if OldText = '' then
+  begin
+    SetError('old_text não informado.');
+    Exit;
+  end;
+  if not FileExists(FileName) then
+  begin
+    SetError('Arquivo não encontrado: ' + FileName);
+    Exit;
+  end;
   S := TStringList.Create;
   try
-    try S.LoadFromFile(FileName); except on E: Exception do begin SetError(E.Message); Exit(False); end; end;
-    Content := S.Text; Matches := CountOccurrences(Content, OldText);
-    if Matches = 0 then begin SetError('Trecho old_text não encontrado.'); Exit; end;
-    if FRequireUniqueMatch and (Matches <> 1) then begin SetError('Trecho ambíguo: ' + IntToStr(Matches) + ' ocorrências.'); Exit; end;
+    try
+      S.LoadFromFile(FileName);
+    except
+      on E: Exception do
+      begin
+        SetError(E.Message);
+        Exit(False);
+      end;
+    end;
+    Content := S.Text;
+    Matches := CountOccurrences(Content, OldText);
+    if Matches = 0 then
+    begin
+      SetError('Trecho old_text não encontrado.');
+      Exit;
+    end;
+    if FRequireUniqueMatch and (Matches <> 1) then
+    begin
+      SetError('Trecho ambíguo: ' + IntToStr(Matches) + ' ocorrências.');
+      Exit;
+    end;
     Content := StringReplace(Content, OldText, NewText, [rfReplaceAll]);
-    if ASimulate then begin SetOutput('SIMULATE replace_source ' + FileName); Exit(True); end;
-    TempFile := FileName + '.aiagent.tmp'; BackupFile := FileName + '.aiagent.bak'; S.Text := Content;
+    if ASimulate then
+    begin
+      SetOutput('SIMULATE replace_source ' + FileName);
+      Exit(True);
+    end;
+    TempFile := FileName + '.aiagent.tmp';
+    BackupFile := FileName + '.aiagent.bak';
+    S.Text := Content;
     try
       S.SaveToFile(TempFile);
       if FileExists(BackupFile) then DeleteFile(BackupFile);
-      if not RenameFile(FileName, BackupFile) then raise Exception.Create('Não foi possível criar backup temporário.');
-      if not RenameFile(TempFile, FileName) then begin RenameFile(BackupFile, FileName); raise Exception.Create('Não foi possível substituir o fonte.'); end;
+      if not RenameFile(FileName, BackupFile) then
+        raise Exception.Create('Não foi possível criar backup temporário.');
+      if not RenameFile(TempFile, FileName) then
+      begin
+        RenameFile(BackupFile, FileName);
+        raise Exception.Create('Não foi possível substituir o fonte.');
+      end;
       DeleteFile(BackupFile);
-    except on E: Exception do begin if FileExists(TempFile) then DeleteFile(TempFile); SetError(E.Message); Exit(False); end; end;
-    SetOutput('Fonte atualizado: ' + FileName); Result := True;
-  finally S.Free; end;
+    except
+      on E: Exception do
+      begin
+        if FileExists(TempFile) then DeleteFile(TempFile);
+        SetError(E.Message);
+        Exit(False);
+      end;
+    end;
+    SetOutput('Fonte atualizado: ' + FileName);
+    Result := True;
+  finally
+    S.Free;
+  end;
 end;
 
 constructor TAIProjectBuildAction.Create(AOwner: TComponent);
-begin inherited Create(AOwner); ActionName := 'build_project'; FBuilderExecutable := 'lazbuild'; FTimeoutMs := 120000; end;
-
-function TAIProjectBuildAction.RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean;
-var ProjectPath, ErrorText, OutputText, ProjectParam: string; Args: TStringList;
 begin
-  Result := False; SetOutput(''); ProjectParam := ParamValue(AParams, 'project'); if ProjectParam = '' then ProjectParam := FProjectFile;
-  if not ResolveWorkspacePath(ProjectParam, ProjectPath, ErrorText) then begin SetError(ErrorText); Exit; end;
-  if not FileExists(ProjectPath) then begin SetError('Projeto não encontrado: ' + ProjectPath); Exit; end;
-  Args := TStringList.Create;
-  try
-    SplitArguments(FBuildArguments, Args); Args.Add(ProjectPath);
-    if ASimulate then begin SetOutput('SIMULATE build_project ' + ProjectPath); Exit(True); end;
-    Result := RunConfiguredProcess(FBuilderExecutable, Args, ExtractFileDir(ProjectPath), FTimeoutMs, OutputText, ErrorText);
-    SetOutput(OutputText); if not Result then SetError(ErrorText + LineEnding + OutputText);
-  finally Args.Free; end;
+  inherited Create(AOwner);
+  ActionName := 'build_project';
+  FBuilderExecutable := 'lazbuild';
+  FTimeoutMs := 120000;
 end;
 
-constructor TAIProjectTestAction.Create(AOwner: TComponent);
-begin inherited Create(AOwner); ActionName := 'run_tests'; FTimeoutMs := 120000; end;
-
-function TAIProjectTestAction.RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean;
-var ExecutablePath, ErrorText, OutputText: string; Args: TStringList;
+function TAIProjectBuildAction.RunAction(const AParams: TStrings;
+  ASimulate: Boolean): Boolean;
+var
+  ProjectPath, ErrorText, OutputText, ProjectParam: string;
+  Args: TStringList;
 begin
-  Result := False; SetOutput('');
-  if not ResolveWorkspacePath(FTestExecutable, ExecutablePath, ErrorText) then begin SetError(ErrorText); Exit; end;
-  if not FileExists(ExecutablePath) then begin SetError('Teste não encontrado: ' + ExecutablePath); Exit; end;
+  Result := False;
+  SetOutput('');
+  ProjectParam := ParamValue(AParams, 'project');
+  if ProjectParam = '' then ProjectParam := FProjectFile;
+  if not ResolveWorkspacePath(ProjectParam, ProjectPath, ErrorText) then
+  begin
+    SetError(ErrorText);
+    Exit;
+  end;
+  if not FileExists(ProjectPath) then
+  begin
+    SetError('Projeto não encontrado: ' + ProjectPath);
+    Exit;
+  end;
   Args := TStringList.Create;
   try
-    SplitArguments(FTestArguments, Args);
-    if ASimulate then begin SetOutput('SIMULATE run_tests ' + ExecutablePath); Exit(True); end;
-    Result := RunConfiguredProcess(ExecutablePath, Args, ExtractFileDir(ExecutablePath), FTimeoutMs, OutputText, ErrorText);
-    SetOutput(OutputText); if not Result then SetError(ErrorText + LineEnding + OutputText);
-  finally Args.Free; end;
+    SplitArguments(FBuildArguments, Args);
+    Args.Add(ProjectPath);
+    if ASimulate then
+    begin
+      SetOutput('SIMULATE build_project ' + ProjectPath);
+      Exit(True);
+    end;
+    Result := RunConfiguredProcess(FBuilderExecutable, Args,
+      ExtractFileDir(ProjectPath), FTimeoutMs, OutputText, ErrorText);
+    SetOutput(OutputText);
+    if not Result then SetError(ErrorText + LineEnding + OutputText);
+  finally
+    Args.Free;
+  end;
 end;
 
 procedure Register;
 begin
-  RegisterComponents('AI Agents', [TAISourceReadAction, TAISourceReplaceAction,
-    TAIProjectBuildAction, TAIProjectTestAction]);
+  RegisterComponents('AI Agents', [TAISourceReadAction,
+    TAISourceReplaceAction, TAIProjectBuildAction]);
 end;
 
 end.

--- a/pacote/AI Agent/aiagent_testaction.pas
+++ b/pacote/AI Agent/aiagent_testaction.pas
@@ -9,8 +9,8 @@ uses
   Classes, SysUtils, Process, aiagent_sourceactions, LResources;
 
 type
-  { Test runner action with trusted executable configuration and workspace-scoped
-    working directory. The LLM can pass arguments but cannot replace the runner. }
+  { Trusted test runner. The application configures the executable; the LLM may
+    supply only arguments. Workspace file access remains confined to WorkspaceRoot. }
   TAITrustedProjectTestAction = class(TAIDeveloperWorkspaceAction)
   private
     FTestExecutable: string;
@@ -49,12 +49,18 @@ begin
   for I := 1 to Length(AText) do
   begin
     C := AText[I];
-    if C = '"' then Quoted := not Quoted
+    if C = '"' then
+      Quoted := not Quoted
     else if (C in [' ', #9]) and not Quoted then
     begin
-      if Token <> '' then begin AArgs.Add(Token); Token := ''; end;
+      if Token <> '' then
+      begin
+        AArgs.Add(Token);
+        Token := '';
+      end;
     end
-    else Token := Token + C;
+    else
+      Token := Token + C;
   end;
   if Token <> '' then AArgs.Add(Token);
 end;
@@ -95,13 +101,18 @@ begin
     try
       P.Execute;
     except
-      on E: Exception do begin AError := E.Message; Exit(False); end;
+      on E: Exception do
+      begin
+        AError := E.Message;
+        Exit(False);
+      end;
     end;
     StartTick := GetTickCount64;
     while P.Running do
     begin
       AOutput := AOutput + ReadProcessOutput(P);
-      if (ATimeoutMs > 0) and (GetTickCount64 - StartTick > QWord(ATimeoutMs)) then
+      if (ATimeoutMs > 0) and
+         (GetTickCount64 - StartTick > QWord(ATimeoutMs)) then
       begin
         P.Terminate(1);
         AError := 'Tempo limite excedido ao executar testes.';
@@ -111,7 +122,8 @@ begin
     end;
     AOutput := AOutput + ReadProcessOutput(P);
     Result := P.ExitStatus = 0;
-    if not Result then AError := 'Testes terminaram com código ' + IntToStr(P.ExitStatus) + '.';
+    if not Result then
+      AError := 'Testes terminaram com código ' + IntToStr(P.ExitStatus) + '.';
   finally
     P.Free;
   end;
@@ -124,7 +136,8 @@ begin
   FTimeoutMs := 120000;
 end;
 
-function TAITrustedProjectTestAction.CommandExists(const ACommand: string): Boolean;
+function TAITrustedProjectTestAction.CommandExists(
+  const ACommand: string): Boolean;
 begin
   if FilenameIsAbsolute(ACommand) or (ExtractFilePath(ACommand) <> '') then
     Exit(FileExists(ACommand));
@@ -135,7 +148,8 @@ function TAITrustedProjectTestAction.RunAction(const AParams: TStrings;
   ASimulate: Boolean): Boolean;
 var
   ErrorText, OutputText, ExtraArgs, Root: string;
-  Args: TStringList;
+  Args, ExtraList: TStringList;
+  I: Integer;
 begin
   Result := False;
   SetOutput('');
@@ -157,28 +171,27 @@ begin
   end;
 
   Args := TStringList.Create;
+  ExtraList := TStringList.Create;
   try
     SplitArguments(FTestArguments, Args);
     ExtraArgs := ParamValue(AParams, 'arguments');
     if Trim(ExtraArgs) <> '' then
     begin
-      with TStringList.Create do
-      try
-        SplitArguments(ExtraArgs, Self);
-        while Count > 0 do begin Args.Add(Strings[0]); Delete(0); end;
-      finally
-        Free;
-      end;
+      SplitArguments(ExtraArgs, ExtraList);
+      for I := 0 to ExtraList.Count - 1 do
+        Args.Add(ExtraList[I]);
     end;
     if ASimulate then
     begin
       SetOutput('SIMULATE run_tests ' + FTestExecutable);
       Exit(True);
     end;
-    Result := RunProcess(FTestExecutable, Args, Root, FTimeoutMs, OutputText, ErrorText);
+    Result := RunProcess(FTestExecutable, Args, Root, FTimeoutMs,
+      OutputText, ErrorText);
     SetOutput(OutputText);
     if not Result then SetError(ErrorText + LineEnding + OutputText);
   finally
+    ExtraList.Free;
     Args.Free;
   end;
 end;

--- a/pacote/AI Agent/aiagent_testaction.pas
+++ b/pacote/AI Agent/aiagent_testaction.pas
@@ -1,0 +1,191 @@
+unit aiagent_testaction;
+
+{$mode objfpc}{$H+}
+{$codepage utf8}
+
+interface
+
+uses
+  Classes, SysUtils, Process, aiagent_sourceactions, LResources;
+
+type
+  { Test runner action with trusted executable configuration and workspace-scoped
+    working directory. The LLM can pass arguments but cannot replace the runner. }
+  TAITrustedProjectTestAction = class(TAIDeveloperWorkspaceAction)
+  private
+    FTestExecutable: string;
+    FTestArguments: string;
+    FTimeoutMs: Integer;
+    function CommandExists(const ACommand: string): Boolean;
+  public
+    constructor Create(AOwner: TComponent); override;
+    function RunAction(const AParams: TStrings; ASimulate: Boolean): Boolean; override;
+  published
+    property TestExecutable: string read FTestExecutable write FTestExecutable;
+    property TestArguments: string read FTestArguments write FTestArguments;
+    property TimeoutMs: Integer read FTimeoutMs write FTimeoutMs default 120000;
+  end;
+
+procedure Register;
+
+implementation
+
+function ParamValue(AParams: TStrings; const AName: string): string;
+begin
+  Result := '';
+  if Assigned(AParams) then Result := AParams.Values[AName];
+end;
+
+procedure SplitArguments(const AText: string; AArgs: TStrings);
+var
+  I: Integer;
+  C: Char;
+  Token: string;
+  Quoted: Boolean;
+begin
+  AArgs.Clear;
+  Token := '';
+  Quoted := False;
+  for I := 1 to Length(AText) do
+  begin
+    C := AText[I];
+    if C = '"' then Quoted := not Quoted
+    else if (C in [' ', #9]) and not Quoted then
+    begin
+      if Token <> '' then begin AArgs.Add(Token); Token := ''; end;
+    end
+    else Token := Token + C;
+  end;
+  if Token <> '' then AArgs.Add(Token);
+end;
+
+function ReadProcessOutput(AProcess: TProcess): string;
+var
+  Buffer: array[0..4095] of Byte;
+  N: LongInt;
+  S: RawByteString;
+begin
+  Result := '';
+  while AProcess.Output.NumBytesAvailable > 0 do
+  begin
+    N := AProcess.Output.Read(Buffer, SizeOf(Buffer));
+    if N <= 0 then Break;
+    SetString(S, PAnsiChar(@Buffer[0]), N);
+    Result := Result + string(S);
+  end;
+end;
+
+function RunProcess(const AExecutable: string; AParams: TStrings;
+  const AWorkingDir: string; ATimeoutMs: Integer; out AOutput,
+  AError: string): Boolean;
+var
+  P: TProcess;
+  StartTick: QWord;
+  I: Integer;
+begin
+  Result := False;
+  AOutput := '';
+  AError := '';
+  P := TProcess.Create(nil);
+  try
+    P.Executable := AExecutable;
+    P.CurrentDirectory := AWorkingDir;
+    P.Options := [poUsePipes, poStderrToOutPut];
+    for I := 0 to AParams.Count - 1 do P.Parameters.Add(AParams[I]);
+    try
+      P.Execute;
+    except
+      on E: Exception do begin AError := E.Message; Exit(False); end;
+    end;
+    StartTick := GetTickCount64;
+    while P.Running do
+    begin
+      AOutput := AOutput + ReadProcessOutput(P);
+      if (ATimeoutMs > 0) and (GetTickCount64 - StartTick > QWord(ATimeoutMs)) then
+      begin
+        P.Terminate(1);
+        AError := 'Tempo limite excedido ao executar testes.';
+        Exit(False);
+      end;
+      Sleep(10);
+    end;
+    AOutput := AOutput + ReadProcessOutput(P);
+    Result := P.ExitStatus = 0;
+    if not Result then AError := 'Testes terminaram com código ' + IntToStr(P.ExitStatus) + '.';
+  finally
+    P.Free;
+  end;
+end;
+
+constructor TAITrustedProjectTestAction.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  ActionName := 'run_tests';
+  FTimeoutMs := 120000;
+end;
+
+function TAITrustedProjectTestAction.CommandExists(const ACommand: string): Boolean;
+begin
+  if FilenameIsAbsolute(ACommand) or (ExtractFilePath(ACommand) <> '') then
+    Exit(FileExists(ACommand));
+  Result := FileSearch(ACommand, GetEnvironmentVariable('PATH')) <> '';
+end;
+
+function TAITrustedProjectTestAction.RunAction(const AParams: TStrings;
+  ASimulate: Boolean): Boolean;
+var
+  ErrorText, OutputText, ExtraArgs, Root: string;
+  Args: TStringList;
+begin
+  Result := False;
+  SetOutput('');
+  Root := ExpandFileName(Trim(WorkspaceRoot));
+  if (Root = '') or not DirectoryExists(Root) then
+  begin
+    SetError('WorkspaceRoot inválido: ' + WorkspaceRoot);
+    Exit;
+  end;
+  if Trim(FTestExecutable) = '' then
+  begin
+    SetError('TestExecutable não configurado.');
+    Exit;
+  end;
+  if not CommandExists(FTestExecutable) then
+  begin
+    SetError('Executável de teste não encontrado: ' + FTestExecutable);
+    Exit;
+  end;
+
+  Args := TStringList.Create;
+  try
+    SplitArguments(FTestArguments, Args);
+    ExtraArgs := ParamValue(AParams, 'arguments');
+    if Trim(ExtraArgs) <> '' then
+    begin
+      with TStringList.Create do
+      try
+        SplitArguments(ExtraArgs, Self);
+        while Count > 0 do begin Args.Add(Strings[0]); Delete(0); end;
+      finally
+        Free;
+      end;
+    end;
+    if ASimulate then
+    begin
+      SetOutput('SIMULATE run_tests ' + FTestExecutable);
+      Exit(True);
+    end;
+    Result := RunProcess(FTestExecutable, Args, Root, FTimeoutMs, OutputText, ErrorText);
+    SetOutput(OutputText);
+    if not Result then SetError(ErrorText + LineEnding + OutputText);
+  finally
+    Args.Free;
+  end;
+end;
+
+procedure Register;
+begin
+  RegisterComponents('AI Agents', [TAITrustedProjectTestAction]);
+end;
+
+end.

--- a/pacote/packages/openai_agent.lpk
+++ b/pacote/packages/openai_agent.lpk
@@ -13,7 +13,7 @@
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
     </CompilerOptions>
-    <Description Value="Lazarus AI Suite: Autonomous agents, planning options, executors and safety locks."/>
+    <Description Value="Lazarus AI Suite: Autonomous agents, planning options, executors, source correction actions and safety locks."/>
     <License Value="OPEN SOURCE GPL3"/>
     <Files>
       <Item><Filename Value="..\AI Agent\aiagent.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent"/></Item>
@@ -27,6 +27,7 @@
       <Item><Filename Value="..\AI Agent\aiagent_decision.pas"/><UnitName Value="aiagent_decision"/></Item>
       <Item><Filename Value="..\AI Agent\aiagent_actionbuilder.pas"/><UnitName Value="aiagent_actionbuilder"/></Item>
       <Item><Filename Value="..\AI Agent\aiagent_actions.pas"/><UnitName Value="aiagent_actions"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_sourceactions.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_sourceactions"/></Item>
       <Item><Filename Value="..\AI Agent\aitools.pas"/><HasRegisterProc Value="True"/><UnitName Value="aitools"/></Item>
       <Item><Filename Value="..\AI Agent\aiagentgraph.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentgraph"/></Item>
       <Item><Filename Value="..\AI Agent\aiguardrails.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiguardrails"/></Item>

--- a/pacote/packages/openai_agent.lpk
+++ b/pacote/packages/openai_agent.lpk
@@ -28,6 +28,7 @@
       <Item><Filename Value="..\AI Agent\aiagent_actionbuilder.pas"/><UnitName Value="aiagent_actionbuilder"/></Item>
       <Item><Filename Value="..\AI Agent\aiagent_actions.pas"/><UnitName Value="aiagent_actions"/></Item>
       <Item><Filename Value="..\AI Agent\aiagent_sourceactions.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_sourceactions"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_testaction.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_testaction"/></Item>
       <Item><Filename Value="..\AI Agent\aitools.pas"/><HasRegisterProc Value="True"/><UnitName Value="aitools"/></Item>
       <Item><Filename Value="..\AI Agent\aiagentgraph.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentgraph"/></Item>
       <Item><Filename Value="..\AI Agent\aiguardrails.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiguardrails"/></Item>

--- a/pacote/samples/AI Agent/source_fix_agent_demo/README.md
+++ b/pacote/samples/AI Agent/source_fix_agent_demo/README.md
@@ -1,0 +1,7 @@
+# source_fix_agent_demo
+
+Minimal Lazarus/FPC console sample showing how to register the reusable developer actions in `TAIActionExecutor`.
+
+The demo registers source read/replace, project build and trusted test actions. It executes a prepared `read_source` action against `README.md` in the workspace supplied on the command line.
+
+Use the same pattern in an IDE: configure `WorkspaceRoot`, register the actions once, let the orchestrator/action builder prepare the JSON plan, execute it, then present diff/diagnostics to the user.

--- a/pacote/samples/AI Agent/source_fix_agent_demo/source_fix_agent_demo.lpi
+++ b/pacote/samples/AI Agent/source_fix_agent_demo/source_fix_agent_demo.lpi
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="source_fix_agent_demo"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+    </BuildModes>
+    <RequiredPackages Count="1">
+      <Item1><PackageName Value="openai_agent"/></Item1>
+    </RequiredPackages>
+    <Units Count="1">
+      <Unit0>
+        <Filename Value="source_fix_agent_demo.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <Target><Filename Value="bin/$(TargetCPU)-$(TargetOS)/source_fix_agent_demo"/></Target>
+    <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
+  </CompilerOptions>
+</CONFIG>

--- a/pacote/samples/AI Agent/source_fix_agent_demo/source_fix_agent_demo.lpr
+++ b/pacote/samples/AI Agent/source_fix_agent_demo/source_fix_agent_demo.lpr
@@ -1,0 +1,57 @@
+program source_fix_agent_demo;
+
+{$mode objfpc}{$H+}
+{$codepage utf8}
+
+uses
+  Classes, SysUtils,
+  aiagent_executor, aiagent_sourceactions, aiagent_testaction;
+
+var
+  Executor: TAIActionExecutor;
+  ReadAction: TAISourceReadAction;
+  ReplaceAction: TAISourceReplaceAction;
+  BuildAction: TAIProjectBuildAction;
+  TestAction: TAITrustedProjectTestAction;
+  Root, Plan, OutputText: string;
+begin
+  if ParamCount < 1 then
+  begin
+    WriteLn('Uso: source_fix_agent_demo <workspace>');
+    Halt(1);
+  end;
+
+  Root := ExpandFileName(ParamStr(1));
+  Executor := TAIActionExecutor.Create(nil);
+  ReadAction := TAISourceReadAction.Create(nil);
+  ReplaceAction := TAISourceReplaceAction.Create(nil);
+  BuildAction := TAIProjectBuildAction.Create(nil);
+  TestAction := TAITrustedProjectTestAction.Create(nil);
+  try
+    ReadAction.WorkspaceRoot := Root;
+    ReplaceAction.WorkspaceRoot := Root;
+    BuildAction.WorkspaceRoot := Root;
+    TestAction.WorkspaceRoot := Root;
+
+    Executor.RegisterAction(ReadAction);
+    Executor.RegisterAction(ReplaceAction);
+    Executor.RegisterAction(BuildAction);
+    Executor.RegisterAction(TestAction);
+
+    Plan := '{"actions":[{"action":"read_source","parameters":{"file":"README.md"}}]}';
+    if not Executor.ExecutePreparedActionsReal(Plan, OutputText) then
+    begin
+      WriteLn(StdErr, Executor.LastError);
+      Halt(2);
+    end;
+
+    WriteLn(OutputText);
+    WriteLn(ReadAction.LastOutput);
+  finally
+    TestAction.Free;
+    BuildAction.Free;
+    ReplaceAction.Free;
+    ReadAction.Free;
+    Executor.Free;
+  end;
+end.

--- a/tests/test_aiagent_sourceactions.lpr
+++ b/tests/test_aiagent_sourceactions.lpr
@@ -4,7 +4,7 @@ program test_aiagent_sourceactions;
 {$codepage utf8}
 
 uses
-  Classes, SysUtils, aiagent_sourceactions;
+  Classes, SysUtils, aiagent_sourceactions, aiagent_testaction;
 
 procedure Check(ACondition: Boolean; const AMessage: string);
 begin
@@ -18,10 +18,11 @@ var
   ReadAction: TAISourceReadAction;
   ReplaceAction: TAISourceReplaceAction;
   BuildAction: TAIProjectBuildAction;
-  TestAction: TAIProjectTestAction;
+  TestAction: TAITrustedProjectTestAction;
   S: TStringList;
 begin
-  Root := IncludeTrailingPathDelimiter(GetTempDir(False)) + 'chatgpt_agent_sourceactions_test';
+  Root := IncludeTrailingPathDelimiter(GetTempDir(False)) +
+    'chatgpt_agent_sourceactions_test';
   ForceDirectories(Root);
   SourceFile := IncludeTrailingPathDelimiter(Root) + 'sample.pas';
   S := TStringList.Create;
@@ -29,15 +30,17 @@ begin
   ReadAction := TAISourceReadAction.Create(nil);
   ReplaceAction := TAISourceReplaceAction.Create(nil);
   BuildAction := TAIProjectBuildAction.Create(nil);
-  TestAction := TAIProjectTestAction.Create(nil);
+  TestAction := TAITrustedProjectTestAction.Create(nil);
   try
-    S.Text := 'unit sample;' + LineEnding + 'const VALUE = 1;' + LineEnding + 'end.' + LineEnding;
+    S.Text := 'unit sample;' + LineEnding + 'const VALUE = 1;' +
+      LineEnding + 'end.' + LineEnding;
     S.SaveToFile(SourceFile);
 
     ReadAction.WorkspaceRoot := Root;
     Params.Values['file'] := 'sample.pas';
     Check(ReadAction.RunAction(Params, False), ReadAction.LastError);
-    Check(Pos('VALUE = 1', ReadAction.LastOutput) > 0, 'read_source não retornou conteúdo.');
+    Check(Pos('VALUE = 1', ReadAction.LastOutput) > 0,
+      'read_source não retornou conteúdo.');
 
     Params.Clear;
     ReplaceAction.WorkspaceRoot := Root;
@@ -49,11 +52,13 @@ begin
     Check(Pos('VALUE = 1', S.Text) > 0, 'simulação alterou o arquivo.');
     Check(ReplaceAction.RunAction(Params, False), ReplaceAction.LastError);
     S.LoadFromFile(SourceFile);
-    Check(Pos('VALUE = 2', S.Text) > 0, 'replace_source não alterou o arquivo.');
+    Check(Pos('VALUE = 2', S.Text) > 0,
+      'replace_source não alterou o arquivo.');
 
     Params.Clear;
     Params.Values['file'] := '../outside.pas';
-    Check(not ReadAction.RunAction(Params, False), 'path traversal não foi bloqueado.');
+    Check(not ReadAction.RunAction(Params, False),
+      'path traversal não foi bloqueado.');
 
     {$IFDEF WINDOWS}
     BuildAction.BuilderExecutable := 'cmd.exe';
@@ -67,7 +72,8 @@ begin
     BuildAction.WorkspaceRoot := Root;
     Params.Clear;
     Check(BuildAction.RunAction(Params, False), BuildAction.LastError);
-    Check(Pos('build-ok', LowerCase(BuildAction.LastOutput)) > 0, 'build_project não capturou saída.');
+    Check(Pos('build-ok', LowerCase(BuildAction.LastOutput)) > 0,
+      'build_project não capturou saída.');
 
     {$IFDEF WINDOWS}
     TestScript := 'cmd.exe';
@@ -79,7 +85,8 @@ begin
     TestAction.WorkspaceRoot := Root;
     TestAction.TestExecutable := TestScript;
     Check(TestAction.RunAction(Params, False), TestAction.LastError);
-    Check(Pos('test-ok', LowerCase(TestAction.LastOutput)) > 0, 'run_tests não capturou saída.');
+    Check(Pos('test-ok', LowerCase(TestAction.LastOutput)) > 0,
+      'run_tests não capturou saída.');
 
     WriteLn('OK: source actions');
   finally

--- a/tests/test_aiagent_sourceactions.lpr
+++ b/tests/test_aiagent_sourceactions.lpr
@@ -1,0 +1,93 @@
+program test_aiagent_sourceactions;
+
+{$mode objfpc}{$H+}
+{$codepage utf8}
+
+uses
+  Classes, SysUtils, aiagent_sourceactions;
+
+procedure Check(ACondition: Boolean; const AMessage: string);
+begin
+  if not ACondition then
+    raise Exception.Create(AMessage);
+end;
+
+var
+  Root, SourceFile, TestScript: string;
+  Params: TStringList;
+  ReadAction: TAISourceReadAction;
+  ReplaceAction: TAISourceReplaceAction;
+  BuildAction: TAIProjectBuildAction;
+  TestAction: TAIProjectTestAction;
+  S: TStringList;
+begin
+  Root := IncludeTrailingPathDelimiter(GetTempDir(False)) + 'chatgpt_agent_sourceactions_test';
+  ForceDirectories(Root);
+  SourceFile := IncludeTrailingPathDelimiter(Root) + 'sample.pas';
+  S := TStringList.Create;
+  Params := TStringList.Create;
+  ReadAction := TAISourceReadAction.Create(nil);
+  ReplaceAction := TAISourceReplaceAction.Create(nil);
+  BuildAction := TAIProjectBuildAction.Create(nil);
+  TestAction := TAIProjectTestAction.Create(nil);
+  try
+    S.Text := 'unit sample;' + LineEnding + 'const VALUE = 1;' + LineEnding + 'end.' + LineEnding;
+    S.SaveToFile(SourceFile);
+
+    ReadAction.WorkspaceRoot := Root;
+    Params.Values['file'] := 'sample.pas';
+    Check(ReadAction.RunAction(Params, False), ReadAction.LastError);
+    Check(Pos('VALUE = 1', ReadAction.LastOutput) > 0, 'read_source não retornou conteúdo.');
+
+    Params.Clear;
+    ReplaceAction.WorkspaceRoot := Root;
+    Params.Values['file'] := 'sample.pas';
+    Params.Values['old_text'] := 'VALUE = 1';
+    Params.Values['new_text'] := 'VALUE = 2';
+    Check(ReplaceAction.RunAction(Params, True), ReplaceAction.LastError);
+    S.LoadFromFile(SourceFile);
+    Check(Pos('VALUE = 1', S.Text) > 0, 'simulação alterou o arquivo.');
+    Check(ReplaceAction.RunAction(Params, False), ReplaceAction.LastError);
+    S.LoadFromFile(SourceFile);
+    Check(Pos('VALUE = 2', S.Text) > 0, 'replace_source não alterou o arquivo.');
+
+    Params.Clear;
+    Params.Values['file'] := '../outside.pas';
+    Check(not ReadAction.RunAction(Params, False), 'path traversal não foi bloqueado.');
+
+    {$IFDEF WINDOWS}
+    BuildAction.BuilderExecutable := 'cmd.exe';
+    BuildAction.BuildArguments := '/C echo build-ok';
+    BuildAction.ProjectFile := 'sample.pas';
+    {$ELSE}
+    BuildAction.BuilderExecutable := '/bin/echo';
+    BuildAction.BuildArguments := 'build-ok';
+    BuildAction.ProjectFile := 'sample.pas';
+    {$ENDIF}
+    BuildAction.WorkspaceRoot := Root;
+    Params.Clear;
+    Check(BuildAction.RunAction(Params, False), BuildAction.LastError);
+    Check(Pos('build-ok', LowerCase(BuildAction.LastOutput)) > 0, 'build_project não capturou saída.');
+
+    {$IFDEF WINDOWS}
+    TestScript := 'cmd.exe';
+    TestAction.TestArguments := '/C echo test-ok';
+    {$ELSE}
+    TestScript := '/bin/echo';
+    TestAction.TestArguments := 'test-ok';
+    {$ENDIF}
+    TestAction.WorkspaceRoot := Root;
+    TestAction.TestExecutable := TestScript;
+    Check(TestAction.RunAction(Params, False), TestAction.LastError);
+    Check(Pos('test-ok', LowerCase(TestAction.LastOutput)) > 0, 'run_tests não capturou saída.');
+
+    WriteLn('OK: source actions');
+  finally
+    TestAction.Free;
+    BuildAction.Free;
+    ReplaceAction.Free;
+    ReadAction.Free;
+    Params.Free;
+    S.Free;
+  end;
+end.


### PR DESCRIPTION
## Objetivo
Adicionar ao pacote CHATGPT ações reutilizáveis para agentes corrigirem fontes indicados pela IA sem duplicar essa lógica nas IDEs consumidoras.

## Ações adicionadas
- `TAISourceReadAction` / `read_source`
- `TAISourceReplaceAction` / `replace_source`
- `TAIProjectBuildAction` / `build_project`
- `TAITrustedProjectTestAction` / `run_tests`

## Segurança
- leitura e alteração de fontes são confinadas a `WorkspaceRoot`;
- bloqueio de path traversal para fora do workspace;
- replace exige ocorrência única por padrão;
- escrita usa arquivo temporário com restauração em caso de falha;
- executáveis de build e teste são configurados pelo host, não escolhidos pela IA;
- o LLM pode fornecer apenas parâmetros previstos;
- suporte a simulação via `ASimulate`.

## Integração
As ações derivam de `TAICustomAgentAction` e são registradas diretamente no `TAIActionExecutor` existente, funcionando com o `TAIAgentOrchestrator` e MemoryMap.

## Qualidade
- testes de leitura, simulação/substituição, bloqueio de path traversal, build e runner de testes;
- sample Lazarus `source_fix_agent_demo` com `.lpi`;
- documentação em `DOC/components/TAISourceActions`.

Somente Lazarus/Free Pascal.