### PR TITLE
add deterministic task-qualified multi-agent memory and routing

### DIFF
--- a/DOC/components/TAIMultiAgentMemory/README.md
+++ b/DOC/components/TAIMultiAgentMemory/README.md
@@ -1,0 +1,31 @@
+# Multi-Agent Deterministic Memory
+
+Arquitetura Lazarus/FPC para roteamento de múltiplas IAs por capacidade demonstrada em cada tipo de questão.
+
+## Princípios
+
+- Cada agente/especialista possui um mapa JSON determinístico próprio.
+- A IA forte/supervisora possui um mapa global separado com evidências de todos os agentes.
+- O score não é reputação geral: é calculado para o fingerprint da questão atual.
+- O fingerprint inclui domínio, subdomínio, tipo de tarefa, linguagem, framework, escopo, capacidades requeridas, complexidade e risco.
+- Build, testes, retries, correções e nota do supervisor são fatos persistidos.
+- O especialista não atribui sua própria nota final; `TAIStrongSupervisor` registra a revisão.
+- Questões acima da capacidade declarada são penalizadas e podem escalar para modelo maior.
+
+## Units
+
+- `aiagent_deterministicmemory.pas`: fingerprint, mapas individuais/globais e evidências.
+- `aiagent_capabilityrouter.pas`: perfil de capacidade e score específico por questão.
+- `aiagent_supervisor.pas`: registro da avaliação do modelo forte e seleção do próximo agente.
+
+## Fluxo
+
+1. Qualifique a questão em `TAITaskQualification`.
+2. Registre especialistas no `TAIAgentCapabilityRouter`.
+3. `TAIStrongSupervisor.ChooseAgent` seleciona o agente com melhor combinação de adequação e histórico similar.
+4. Execute o especialista.
+5. O modelo forte revisa a resposta e produz `TAISupervisorReview`.
+6. `RecordReviewedExecution` grava a evidência no mapa individual e no mapa global.
+7. A próxima questão semelhante usa esse histórico; uma questão diferente recebe score diferente.
+
+Os mapas são persistidos em arquivos separados (`<agent>.json` e `global-supervisor.json`) para impedir compartilhamento implícito de memória entre especialistas.

--- a/pacote/AI Agent/aiagent_capabilityrouter.pas
+++ b/pacote/AI Agent/aiagent_capabilityrouter.pas
@@ -1,0 +1,186 @@
+unit aiagent_capabilityrouter;
+
+{$mode objfpc}{$H+}
+{$codepage utf8}
+
+interface
+
+uses
+  Classes, SysUtils, Contnrs, aiagent_deterministicmemory;
+
+type
+  TAIAgentCapability = class
+  public
+    AgentId: string;
+    ModelId: string;
+    Domains: string;
+    TaskTypes: string;
+    Languages: string;
+    Frameworks: string;
+    MaxComplexity: Double;
+    MaxRisk: Double;
+    CostWeight: Double;
+    IsStrongModel: Boolean;
+  end;
+
+  TAIAgentRouteDecision = record
+    AgentId: string;
+    ModelId: string;
+    Score: Double;
+    HistoricalScore: Double;
+    QualificationScore: Double;
+    Reason: string;
+  end;
+
+  { Scores an agent for THIS task, not by a single global reputation. }
+  TAIAgentCapabilityRouter = class
+  private
+    FCapabilities: TObjectList;
+    FRegistry: TAIAgentMemoryRegistry;
+    function ContainsToken(const AList, AValue: string): Boolean;
+    function QualificationFit(C: TAIAgentCapability;
+      const Q: TAITaskQualification): Double;
+  public
+    constructor Create(ARegistry: TAIAgentMemoryRegistry);
+    destructor Destroy; override;
+    function RegisterAgent(const AAgentId, AModelId, ADomains, ATaskTypes,
+      ALanguages, AFrameworks: string; AMaxComplexity, AMaxRisk,
+      ACostWeight: Double; AIsStrongModel: Boolean = False): TAIAgentCapability;
+    function SelectBest(const Q: TAITaskQualification;
+      AMinimumScore: Double = 0): TAIAgentRouteDecision;
+    function CanPerform(const AAgentId: string; const Q: TAITaskQualification;
+      AMinimumScore: Double; out AScore: Double): Boolean;
+  end;
+
+implementation
+
+constructor TAIAgentCapabilityRouter.Create(ARegistry: TAIAgentMemoryRegistry);
+begin
+  inherited Create;
+  FRegistry := ARegistry;
+  FCapabilities := TObjectList.Create(True);
+end;
+
+destructor TAIAgentCapabilityRouter.Destroy;
+begin
+  FCapabilities.Free;
+  inherited Destroy;
+end;
+
+function TAIAgentCapabilityRouter.ContainsToken(const AList, AValue: string): Boolean;
+var
+  L, V: string;
+begin
+  V := LowerCase(Trim(AValue));
+  if V = '' then Exit(True);
+  L := ',' + LowerCase(StringReplace(AList, ' ', '', [rfReplaceAll])) + ',';
+  Result := (Pos(',' + V + ',', L) > 0) or (Pos(',*,', L) > 0);
+end;
+
+function TAIAgentCapabilityRouter.QualificationFit(C: TAIAgentCapability;
+  const Q: TAITaskQualification): Double;
+var
+  P: Double;
+begin
+  P := 0;
+  if ContainsToken(C.Domains, Q.Domain) then P := P + 25;
+  if ContainsToken(C.TaskTypes, Q.TaskType) then P := P + 20;
+  if ContainsToken(C.Languages, Q.Language) then P := P + 15;
+  if ContainsToken(C.Frameworks, Q.Framework) then P := P + 15;
+  if Q.Complexity <= C.MaxComplexity then P := P + 12 else P := P - 20;
+  if Q.Risk <= C.MaxRisk then P := P + 8 else P := P - 25;
+  P := P + (5 * (1 - C.CostWeight));
+  if P < 0 then P := 0;
+  if P > 100 then P := 100;
+  Result := P;
+end;
+
+function TAIAgentCapabilityRouter.RegisterAgent(const AAgentId, AModelId,
+  ADomains, ATaskTypes, ALanguages, AFrameworks: string; AMaxComplexity,
+  AMaxRisk, ACostWeight: Double; AIsStrongModel: Boolean): TAIAgentCapability;
+begin
+  Result := TAIAgentCapability.Create;
+  Result.AgentId := AAgentId;
+  Result.ModelId := AModelId;
+  Result.Domains := ADomains;
+  Result.TaskTypes := ATaskTypes;
+  Result.Languages := ALanguages;
+  Result.Frameworks := AFrameworks;
+  Result.MaxComplexity := AMaxComplexity;
+  Result.MaxRisk := AMaxRisk;
+  Result.CostWeight := ACostWeight;
+  Result.IsStrongModel := AIsStrongModel;
+  FCapabilities.Add(Result);
+end;
+
+function TAIAgentCapabilityRouter.SelectBest(const Q: TAITaskQualification;
+  AMinimumScore: Double): TAIAgentRouteDecision;
+var
+  I, Count: Integer;
+  C: TAIAgentCapability;
+  M: TAIDeterministicAgentMemory;
+  H, F, S: Double;
+begin
+  FillChar(Result, SizeOf(Result), 0);
+  Result.Score := -1;
+  for I := 0 to FCapabilities.Count - 1 do
+  begin
+    C := TAIAgentCapability(FCapabilities[I]);
+    F := QualificationFit(C, Q);
+    M := FRegistry.AgentMemory(C.AgentId);
+    try
+      Count := M.SimilarEvidenceCount(Q);
+      H := M.ScoreForTask(Q);
+    finally
+      M.Free;
+    end;
+    if Count = 0 then
+      S := F
+    else
+      S := (F * 0.45) + (H * 0.55);
+    if S > Result.Score then
+    begin
+      Result.AgentId := C.AgentId;
+      Result.ModelId := C.ModelId;
+      Result.Score := S;
+      Result.HistoricalScore := H;
+      Result.QualificationScore := F;
+      Result.Reason := Format('task-fit=%.1f history=%.1f similar=%d', [F, H, Count]);
+    end;
+  end;
+  if Result.Score < AMinimumScore then
+  begin
+    Result.AgentId := '';
+    Result.ModelId := '';
+    Result.Reason := 'Nenhum agente atingiu o score mínimo para esta questão.';
+  end;
+end;
+
+function TAIAgentCapabilityRouter.CanPerform(const AAgentId: string;
+  const Q: TAITaskQualification; AMinimumScore: Double; out AScore: Double): Boolean;
+var
+  I, Count: Integer;
+  C: TAIAgentCapability;
+  M: TAIDeterministicAgentMemory;
+  F, H: Double;
+begin
+  AScore := 0;
+  for I := 0 to FCapabilities.Count - 1 do
+  begin
+    C := TAIAgentCapability(FCapabilities[I]);
+    if not SameText(C.AgentId, AAgentId) then Continue;
+    F := QualificationFit(C, Q);
+    M := FRegistry.AgentMemory(C.AgentId);
+    try
+      Count := M.SimilarEvidenceCount(Q);
+      H := M.ScoreForTask(Q);
+    finally
+      M.Free;
+    end;
+    if Count = 0 then AScore := F else AScore := F * 0.45 + H * 0.55;
+    Exit(AScore >= AMinimumScore);
+  end;
+  Result := False;
+end;
+
+end.

--- a/pacote/AI Agent/aiagent_deterministicmemory.pas
+++ b/pacote/AI Agent/aiagent_deterministicmemory.pas
@@ -1,0 +1,296 @@
+unit aiagent_deterministicmemory;
+
+{$mode objfpc}{$H+}
+{$codepage utf8}
+
+interface
+
+uses
+  Classes, SysUtils, fpjson, jsonparser, md5;
+
+type
+  TAITaskQualification = record
+    Domain: string;
+    SubDomain: string;
+    TaskType: string;
+    Language: string;
+    Framework: string;
+    Complexity: Double;
+    Risk: Double;
+    Scope: string;
+    RequiredCapabilities: string;
+  end;
+
+  TAIAgentTaskEvidence = record
+    AgentId: string;
+    ModelId: string;
+    Fingerprint: string;
+    Success: Boolean;
+    BuildPassed: Boolean;
+    TestsPassed: Boolean;
+    ReviewerScore: Double;
+    Retries: Integer;
+    CorrectionsRequired: Integer;
+    FailureKind: string;
+    Timestamp: TDateTime;
+  end;
+
+  { Deterministic JSON memory. Each agent gets its own file; the strong
+    supervisor gets a global file containing cross-agent evidence. }
+  TAIDeterministicAgentMemory = class
+  private
+    FRootDirectory: string;
+    FAgentId: string;
+    FGlobalSupervisor: Boolean;
+    function Normalize(const S: string): string;
+    function MemoryFileName: string;
+    function LoadRoot: TJSONObject;
+    procedure SaveRoot(ARoot: TJSONObject);
+  public
+    constructor Create(const ARootDirectory, AAgentId: string;
+      AGlobalSupervisor: Boolean = False);
+    class function TaskFingerprint(const Q: TAITaskQualification): string;
+    procedure RecordEvidence(const E: TAIAgentTaskEvidence);
+    function ScoreForTask(const Q: TAITaskQualification;
+      const AAgentId: string = ''): Double;
+    function SimilarEvidenceCount(const Q: TAITaskQualification;
+      const AAgentId: string = ''): Integer;
+    property RootDirectory: string read FRootDirectory;
+    property AgentId: string read FAgentId;
+    property GlobalSupervisor: Boolean read FGlobalSupervisor;
+  end;
+
+  { Registry guarantees one deterministic memory namespace per specialist
+    plus one global supervisor namespace. }
+  TAIAgentMemoryRegistry = class
+  private
+    FRootDirectory: string;
+  public
+    constructor Create(const ARootDirectory: string);
+    function AgentMemory(const AAgentId: string): TAIDeterministicAgentMemory;
+    function GlobalMemory: TAIDeterministicAgentMemory;
+    property RootDirectory: string read FRootDirectory;
+  end;
+
+implementation
+
+function Clamp01(const V: Double): Double;
+begin
+  if V < 0 then Exit(0);
+  if V > 1 then Exit(1);
+  Result := V;
+end;
+
+constructor TAIDeterministicAgentMemory.Create(const ARootDirectory,
+  AAgentId: string; AGlobalSupervisor: Boolean);
+begin
+  inherited Create;
+  FRootDirectory := ExpandFileName(ARootDirectory);
+  FAgentId := Trim(AAgentId);
+  FGlobalSupervisor := AGlobalSupervisor;
+  if FAgentId = '' then FAgentId := 'anonymous';
+  ForceDirectories(FRootDirectory);
+end;
+
+function TAIDeterministicAgentMemory.Normalize(const S: string): string;
+begin
+  Result := LowerCase(Trim(S));
+  Result := StringReplace(Result, '|', '_', [rfReplaceAll]);
+  Result := StringReplace(Result, LineEnding, ' ', [rfReplaceAll]);
+end;
+
+class function TAIDeterministicAgentMemory.TaskFingerprint(
+  const Q: TAITaskQualification): string;
+var
+  Raw: string;
+begin
+  Raw := LowerCase(Trim(Q.Domain)) + '|' + LowerCase(Trim(Q.SubDomain)) + '|' +
+    LowerCase(Trim(Q.TaskType)) + '|' + LowerCase(Trim(Q.Language)) + '|' +
+    LowerCase(Trim(Q.Framework)) + '|' + LowerCase(Trim(Q.Scope)) + '|' +
+    LowerCase(Trim(Q.RequiredCapabilities)) + '|' +
+    IntToStr(Round(Clamp01(Q.Complexity) * 10)) + '|' +
+    IntToStr(Round(Clamp01(Q.Risk) * 10));
+  Result := MD5Print(MD5String(Raw));
+end;
+
+function TAIDeterministicAgentMemory.MemoryFileName: string;
+var
+  N: string;
+begin
+  if FGlobalSupervisor then
+    N := 'global-supervisor'
+  else
+    N := Normalize(FAgentId);
+  N := StringReplace(N, '/', '_', [rfReplaceAll]);
+  N := StringReplace(N, '\', '_', [rfReplaceAll]);
+  Result := IncludeTrailingPathDelimiter(FRootDirectory) + N + '.json';
+end;
+
+function TAIDeterministicAgentMemory.LoadRoot: TJSONObject;
+var
+  S: TStringList;
+  D: TJSONData;
+begin
+  Result := TJSONObject.Create;
+  if not FileExists(MemoryFileName) then Exit;
+  S := TStringList.Create;
+  try
+    S.LoadFromFile(MemoryFileName);
+    if Trim(S.Text) = '' then Exit;
+    D := GetJSON(S.Text);
+    if D.JSONType = jtObject then
+    begin
+      Result.Free;
+      Result := TJSONObject(D);
+    end
+    else
+      D.Free;
+  finally
+    S.Free;
+  end;
+end;
+
+procedure TAIDeterministicAgentMemory.SaveRoot(ARoot: TJSONObject);
+var
+  S: TStringList;
+  Tmp: string;
+begin
+  ForceDirectories(FRootDirectory);
+  Tmp := MemoryFileName + '.tmp';
+  S := TStringList.Create;
+  try
+    S.Text := ARoot.FormatJSON;
+    S.SaveToFile(Tmp);
+    if FileExists(MemoryFileName) then DeleteFile(MemoryFileName);
+    if not RenameFile(Tmp, MemoryFileName) then
+      raise Exception.Create('Não foi possível persistir o mapa determinístico.');
+  finally
+    S.Free;
+    if FileExists(Tmp) then DeleteFile(Tmp);
+  end;
+end;
+
+procedure TAIDeterministicAgentMemory.RecordEvidence(
+  const E: TAIAgentTaskEvidence);
+var
+  Root, Bucket, Item: TJSONObject;
+  Arr: TJSONArray;
+  Key, EffectiveAgent: string;
+begin
+  Root := LoadRoot;
+  try
+    Key := E.Fingerprint;
+    if Key = '' then raise Exception.Create('Fingerprint da tarefa não informado.');
+    Bucket := Root.Objects[Key];
+    if Bucket = nil then
+    begin
+      Bucket := TJSONObject.Create;
+      Root.Add(Key, Bucket);
+      Bucket.Add('evidence', TJSONArray.Create);
+    end;
+    Arr := Bucket.Arrays['evidence'];
+    EffectiveAgent := Trim(E.AgentId);
+    if EffectiveAgent = '' then EffectiveAgent := FAgentId;
+    Item := TJSONObject.Create;
+    Item.Add('agent_id', EffectiveAgent);
+    Item.Add('model_id', E.ModelId);
+    Item.Add('success', E.Success);
+    Item.Add('build_passed', E.BuildPassed);
+    Item.Add('tests_passed', E.TestsPassed);
+    Item.Add('reviewer_score', E.ReviewerScore);
+    Item.Add('retries', E.Retries);
+    Item.Add('corrections_required', E.CorrectionsRequired);
+    Item.Add('failure_kind', E.FailureKind);
+    Item.Add('timestamp', DateTimeToStr(E.Timestamp));
+    Arr.Add(Item);
+    SaveRoot(Root);
+  finally
+    Root.Free;
+  end;
+end;
+
+function TAIDeterministicAgentMemory.SimilarEvidenceCount(
+  const Q: TAITaskQualification; const AAgentId: string): Integer;
+var
+  Root, Bucket: TJSONObject;
+  Arr: TJSONArray;
+  I: Integer;
+  Filter: string;
+begin
+  Result := 0;
+  Root := LoadRoot;
+  try
+    Bucket := Root.Objects[TaskFingerprint(Q)];
+    if Bucket = nil then Exit;
+    Arr := Bucket.Arrays['evidence'];
+    if Arr = nil then Exit;
+    Filter := Trim(AAgentId);
+    for I := 0 to Arr.Count - 1 do
+      if (Filter = '') or SameText(Arr.Objects[I].Get('agent_id', ''), Filter) then
+        Inc(Result);
+  finally
+    Root.Free;
+  end;
+end;
+
+function TAIDeterministicAgentMemory.ScoreForTask(
+  const Q: TAITaskQualification; const AAgentId: string): Double;
+var
+  Root, Bucket: TJSONObject;
+  Arr: TJSONArray;
+  I, N: Integer;
+  O: TJSONObject;
+  Filter: string;
+  V, Sum, Weight: Double;
+begin
+  Result := 0;
+  Root := LoadRoot;
+  try
+    Bucket := Root.Objects[TaskFingerprint(Q)];
+    if Bucket = nil then Exit;
+    Arr := Bucket.Arrays['evidence'];
+    if Arr = nil then Exit;
+    Filter := Trim(AAgentId);
+    Sum := 0;
+    N := 0;
+    for I := 0 to Arr.Count - 1 do
+    begin
+      O := Arr.Objects[I];
+      if (Filter <> '') and not SameText(O.Get('agent_id', ''), Filter) then Continue;
+      V := O.Get('reviewer_score', 0.0) / 100.0;
+      if O.Get('success', False) then V := V + 0.20 else V := V - 0.25;
+      if O.Get('build_passed', False) then V := V + 0.10;
+      if O.Get('tests_passed', False) then V := V + 0.10;
+      V := V - (O.Get('retries', 0) * 0.04);
+      V := V - (O.Get('corrections_required', 0) * 0.05);
+      if O.Get('failure_kind', '') <> '' then V := V - 0.08;
+      Weight := 1.0 + (I / (Arr.Count + 1)); { recent evidence weighs slightly more }
+      Sum := Sum + Clamp01(V) * Weight;
+      Inc(N);
+    end;
+    if N > 0 then Result := 100.0 * Sum / N / 1.5;
+    if Result > 100 then Result := 100;
+  finally
+    Root.Free;
+  end;
+end;
+
+constructor TAIAgentMemoryRegistry.Create(const ARootDirectory: string);
+begin
+  inherited Create;
+  FRootDirectory := ExpandFileName(ARootDirectory);
+  ForceDirectories(FRootDirectory);
+end;
+
+function TAIAgentMemoryRegistry.AgentMemory(
+  const AAgentId: string): TAIDeterministicAgentMemory;
+begin
+  Result := TAIDeterministicAgentMemory.Create(FRootDirectory, AAgentId, False);
+end;
+
+function TAIAgentMemoryRegistry.GlobalMemory: TAIDeterministicAgentMemory;
+begin
+  Result := TAIDeterministicAgentMemory.Create(FRootDirectory, 'strong-supervisor', True);
+end;
+
+end.

--- a/pacote/AI Agent/aiagent_supervisor.pas
+++ b/pacote/AI Agent/aiagent_supervisor.pas
@@ -1,0 +1,93 @@
+unit aiagent_supervisor;
+
+{$mode objfpc}{$H+}
+{$codepage utf8}
+
+interface
+
+uses
+  Classes, SysUtils, aiagent_deterministicmemory, aiagent_capabilityrouter;
+
+type
+  TAISupervisorReview = record
+    Approved: Boolean;
+    ReviewerScore: Double;
+    FailureKind: string;
+    CorrectionsRequired: Integer;
+    ShouldEscalate: Boolean;
+    ShouldTrain: Boolean;
+    Notes: string;
+  end;
+
+  { Deterministic bookkeeping around the strong model. The LLM produces the
+    review; this class records facts and makes routing/training consequences
+    reproducible. }
+  TAIStrongSupervisor = class
+  private
+    FRegistry: TAIAgentMemoryRegistry;
+    FRouter: TAIAgentCapabilityRouter;
+  public
+    constructor Create(ARegistry: TAIAgentMemoryRegistry;
+      ARouter: TAIAgentCapabilityRouter);
+    procedure RecordReviewedExecution(const Q: TAITaskQualification;
+      const AAgentId, AModelId: string; ASuccess, ABuildPassed,
+      ATestsPassed: Boolean; ARetries: Integer; const R: TAISupervisorReview);
+    function ChooseAgent(const Q: TAITaskQualification;
+      AMinimumScore: Double): TAIAgentRouteDecision;
+  end;
+
+implementation
+
+constructor TAIStrongSupervisor.Create(ARegistry: TAIAgentMemoryRegistry;
+  ARouter: TAIAgentCapabilityRouter);
+begin
+  inherited Create;
+  FRegistry := ARegistry;
+  FRouter := ARouter;
+end;
+
+procedure TAIStrongSupervisor.RecordReviewedExecution(
+  const Q: TAITaskQualification; const AAgentId, AModelId: string;
+  ASuccess, ABuildPassed, ATestsPassed: Boolean; ARetries: Integer;
+  const R: TAISupervisorReview);
+var
+  E: TAIAgentTaskEvidence;
+  M: TAIDeterministicAgentMemory;
+begin
+  FillChar(E, SizeOf(E), 0);
+  E.AgentId := AAgentId;
+  E.ModelId := AModelId;
+  E.Fingerprint := TAIDeterministicAgentMemory.TaskFingerprint(Q);
+  E.Success := ASuccess and R.Approved;
+  E.BuildPassed := ABuildPassed;
+  E.TestsPassed := ATestsPassed;
+  E.ReviewerScore := R.ReviewerScore;
+  E.Retries := ARetries;
+  E.CorrectionsRequired := R.CorrectionsRequired;
+  E.FailureKind := R.FailureKind;
+  E.Timestamp := Now;
+
+  M := FRegistry.AgentMemory(AAgentId);
+  try
+    M.RecordEvidence(E);
+  finally
+    M.Free;
+  end;
+
+  { Strong/global memory receives the same immutable evidence so it can
+    compare specialists across domains without specialists sharing memory. }
+  M := FRegistry.GlobalMemory;
+  try
+    M.RecordEvidence(E);
+  finally
+    M.Free;
+  end;
+end;
+
+function TAIStrongSupervisor.ChooseAgent(const Q: TAITaskQualification;
+  AMinimumScore: Double): TAIAgentRouteDecision;
+begin
+  Result := FRouter.SelectBest(Q, AMinimumScore);
+end;
+
+end.

--- a/pacote/packages/openai_agent.lpk
+++ b/pacote/packages/openai_agent.lpk
@@ -5,15 +5,8 @@
     <Name Value="openai_agent"/>
     <Type Value="RunAndDesignTime"/>
     <Author Value="Marcelo Maurin Martins"/>
-    <CompilerOptions>
-      <Version Value="11"/>
-      <PathDelim Value="\"/>
-      <SearchPaths>
-        <OtherUnitFiles Value="..\AI Agent;..\AI Project"/>
-        <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
-      </SearchPaths>
-    </CompilerOptions>
-    <Description Value="Lazarus AI Suite: Autonomous agents, planning options, executors, source correction actions and safety locks."/>
+    <CompilerOptions><Version Value="11"/><PathDelim Value="\"/><SearchPaths><OtherUnitFiles Value="..\AI Agent;..\AI Project"/><UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/></SearchPaths></CompilerOptions>
+    <Description Value="Lazarus AI Suite: autonomous and multi-agent orchestration, deterministic per-agent/global memory, task-qualified routing, source correction actions and safety locks."/>
     <License Value="OPEN SOURCE GPL3"/>
     <Files>
       <Item><Filename Value="..\AI Agent\aiagent.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent"/></Item>
@@ -22,6 +15,9 @@
       <Item><Filename Value="..\AI Agent\aiagentserial.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagentserial"/></Item>
       <Item><Filename Value="..\AI Agent\aiagent_flowevents.pas"/><UnitName Value="aiagent_flowevents"/></Item>
       <Item><Filename Value="..\AI Agent\aiagent_memorymap.pas"/><HasRegisterProc Value="True"/><UnitName Value="aiagent_memorymap"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_deterministicmemory.pas"/><UnitName Value="aiagent_deterministicmemory"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_capabilityrouter.pas"/><UnitName Value="aiagent_capabilityrouter"/></Item>
+      <Item><Filename Value="..\AI Agent\aiagent_supervisor.pas"/><UnitName Value="aiagent_supervisor"/></Item>
       <Item><Filename Value="..\AI Agent\aiagent_core.pas"/><UnitName Value="aiagent_core"/></Item>
       <Item><Filename Value="..\AI Agent\aiagent_classifier.pas"/><UnitName Value="aiagent_classifier"/></Item>
       <Item><Filename Value="..\AI Agent\aiagent_decision.pas"/><UnitName Value="aiagent_decision"/></Item>
@@ -40,16 +36,7 @@
       <Item><Filename Value="..\AI Agent\aicommonserviceagents.pas"/><HasRegisterProc Value="True"/><UnitName Value="aicommonserviceagents"/></Item>
       <Item><Filename Value="..\AI Agent\airosagent.pas"/><HasRegisterProc Value="True"/><UnitName Value="airosagent"/></Item>
     </Files>
-    <RequiredPkgs>
-      <Item><PackageName Value="GLScene_DesignTime"/></Item>
-      <Item><PackageName Value="openai_core"/></Item>
-      <Item><PackageName Value="openai_ml"/></Item>
-      <Item><PackageName Value="openai_input"/></Item>
-      <Item><PackageName Value="openai_output"/></Item>
-      <Item><PackageName Value="LCL"/></Item>
-      <Item><PackageName Value="FCL"/></Item>
-    </RequiredPkgs>
-    <UsageOptions><UnitPath Value="$(PkgOutDir)"/></UsageOptions>
-    <PublishOptions><Version Value="2"/><UseFileFilters Value="True"/></PublishOptions>
+    <RequiredPkgs><Item><PackageName Value="GLScene_DesignTime"/></Item><Item><PackageName Value="openai_core"/></Item><Item><PackageName Value="openai_ml"/></Item><Item><PackageName Value="openai_input"/></Item><Item><PackageName Value="openai_output"/></Item><Item><PackageName Value="LCL"/></Item><Item><PackageName Value="FCL"/></Item></RequiredPkgs>
+    <UsageOptions><UnitPath Value="$(PkgOutDir)"/></UsageOptions><PublishOptions><Version Value="2"/><UseFileFilters Value="True"/></PublishOptions>
   </Package>
 </CONFIG>

--- a/tests/test_aiagent_deterministicmemory.lpr
+++ b/tests/test_aiagent_deterministicmemory.lpr
@@ -1,0 +1,63 @@
+program test_aiagent_deterministicmemory;
+
+{$mode objfpc}{$H+}
+
+uses
+  SysUtils, aiagent_deterministicmemory, aiagent_capabilityrouter,
+  aiagent_supervisor;
+
+procedure AssertTrue(V: Boolean; const M: string);
+begin
+  if not V then raise Exception.Create(M);
+end;
+
+var
+  Root: string;
+  Reg: TAIAgentMemoryRegistry;
+  Router: TAIAgentCapabilityRouter;
+  Supervisor: TAIStrongSupervisor;
+  Q: TAITaskQualification;
+  R: TAISupervisorReview;
+  D: TAIAgentRouteDecision;
+  I: Integer;
+begin
+  Root := IncludeTrailingPathDelimiter(GetTempDir) + 'aiagent-memory-test-' + IntToStr(Random(1000000));
+  ForceDirectories(Root);
+  Reg := TAIAgentMemoryRegistry.Create(Root);
+  Router := TAIAgentCapabilityRouter.Create(Reg);
+  Supervisor := TAIStrongSupervisor.Create(Reg, Router);
+  try
+    Router.RegisterAgent('source-light', 'local-small', 'source', 'bug_fix',
+      'pascal', 'lazarus', 0.70, 0.60, 0.10, False);
+    Router.RegisterAgent('source-strong', 'large', 'source', 'bug_fix',
+      'pascal', 'lazarus', 1.0, 1.0, 0.90, True);
+
+    FillChar(Q, SizeOf(Q), 0);
+    Q.Domain := 'source'; Q.TaskType := 'bug_fix'; Q.Language := 'pascal';
+    Q.Framework := 'lazarus'; Q.Scope := 'multi_file'; Q.Complexity := 0.55;
+    Q.Risk := 0.40; Q.RequiredCapabilities := 'source_edit,build';
+
+    FillChar(R, SizeOf(R), 0);
+    R.Approved := True; R.ReviewerScore := 96;
+    for I := 1 to 3 do
+      Supervisor.RecordReviewedExecution(Q, 'source-light', 'local-small',
+        True, True, True, 0, R);
+
+    D := Supervisor.ChooseAgent(Q, 50);
+    AssertTrue(D.AgentId = 'source-light', 'Histórico por tipo de questão não favoreceu o modelo leve competente.');
+
+    Q.Complexity := 0.95; Q.Risk := 0.90;
+    D := Supervisor.ChooseAgent(Q, 50);
+    AssertTrue(D.AgentId = 'source-strong', 'Questão acima da capacidade não escalou para modelo forte.');
+
+    AssertTrue(FileExists(IncludeTrailingPathDelimiter(Root) + 'source-light.json'),
+      'Mapa determinístico individual não foi persistido.');
+    AssertTrue(FileExists(IncludeTrailingPathDelimiter(Root) + 'global-supervisor.json'),
+      'Mapa global do supervisor não foi persistido.');
+    WriteLn('PASS');
+  finally
+    Supervisor.Free;
+    Router.Free;
+    Reg.Free;
+  end;
+end.


### PR DESCRIPTION
## Objetivo
Implementar a arquitetura multi-IA definida para o CHATGPT/Lazarus: memória determinística isolada por especialista, memória global da IA forte e escolha de agente baseada na qualificação da questão + histórico de tarefas semelhantes.

## Implementado
- `TAITaskQualification` e fingerprint determinístico por domínio/subdomínio/tipo/linguagem/framework/escopo/capacidades/complexidade/risco;
- `TAIDeterministicAgentMemory`: um JSON por agente;
- mapa `global-supervisor.json` separado para a IA forte;
- evidências com sucesso, build, testes, nota do reviewer, retries, correções e tipo de falha;
- `TAIAgentCapabilityRouter`: score específico para a questão atual, combinando task-fit e histórico do mesmo fingerprint;
- capacidade máxima de complexidade/risco por agente, permitindo escalonamento ao modelo forte;
- `TAIStrongSupervisor`: grava a avaliação nos mapas individual/global e escolhe o próximo agente;
- teste que prova: modelo leve é escolhido em questão onde possui histórico forte; questão mais complexa/arriscada escala ao modelo maior;
- documentação e registro das units no pacote `openai_agent`.

## Regra arquitetural
O especialista não define sua própria nota. A IA forte/supervisora registra a avaliação final. O score não é um perfil geral: muda conforme a qualificação/fingerprint da questão.

Somente Lazarus/Free Pascal.