### PR TITLE
Corrige detecção do Python 3 no instalador Windows

### DIFF
--- a/install_components.bat
+++ b/install_components.bat
@@ -10,17 +10,58 @@ if /I "%MODE%"=="help" goto :help
 if /I "%MODE%"=="--help" goto :help
 if /I "%MODE%"=="-h" goto :help
 
-set "PYTHON_BIN=python"
-where py.exe >nul 2>nul && set "PYTHON_BIN=py -3"
+call :find_python
+if errorlevel 1 exit /b 2
 
 if "%LAZBUILD%"=="" (
-  %PYTHON_BIN% "%ROOT_DIR%installer\common\install_suite.py" install --profile "%MODE%"
+  "%PYTHON_BIN%" %PYTHON_ARGS% "%ROOT_DIR%installer\common\install_suite.py" install --profile "%MODE%"
 ) else (
-  %PYTHON_BIN% "%ROOT_DIR%installer\common\install_suite.py" install --profile "%MODE%" --lazbuild "%LAZBUILD%"
+  "%PYTHON_BIN%" %PYTHON_ARGS% "%ROOT_DIR%installer\common\install_suite.py" install --profile "%MODE%" --lazbuild "%LAZBUILD%"
 )
 exit /b %ERRORLEVEL%
 
 :help
 echo Uso: install_components.bat [core^|recommended^|all] [caminho_lazbuild.exe]
-echo Variaveis opcionais: ZEOS_ROOT, CEF4DELPHI_ROOT e GLSCENE_ROOT.
+echo Variaveis opcionais: PYTHON_EXE, ZEOS_ROOT, CEF4DELPHI_ROOT e GLSCENE_ROOT.
+exit /b 0
+
+:find_python
+set "PYTHON_BIN="
+set "PYTHON_ARGS="
+
+if defined PYTHON_EXE (
+  call :try_python "%PYTHON_EXE%" ""
+  if not errorlevel 1 exit /b 0
+)
+
+where py.exe >nul 2>nul
+if not errorlevel 1 (
+  call :try_python "py" "-3"
+  if not errorlevel 1 exit /b 0
+)
+
+where python3.exe >nul 2>nul
+if not errorlevel 1 (
+  call :try_python "python3" ""
+  if not errorlevel 1 exit /b 0
+)
+
+where python.exe >nul 2>nul
+if not errorlevel 1 (
+  call :try_python "python" ""
+  if not errorlevel 1 exit /b 0
+)
+
+echo [ERRO] Python 3.8 ou superior nao encontrado.
+echo        O instalador nao funciona com Python 2.
+echo        No Windows 7 SP1, instale o Python 3.8.10 com o launcher e o PATH habilitados.
+echo        Como alternativa, informe o executavel:
+echo        set "PYTHON_EXE=C:\caminho\para\python.exe"
+exit /b 1
+
+:try_python
+"%~1" %~2 -c "import sys; raise SystemExit(0 if sys.version_info ^>= (3, 8) else 1)" >nul 2>nul
+if errorlevel 1 exit /b 1
+set "PYTHON_BIN=%~1"
+set "PYTHON_ARGS=%~2"
 exit /b 0

--- a/installer/README.md
+++ b/installer/README.md
@@ -4,6 +4,27 @@ O instalador resolve dependências de compilação, registra os pacotes na ordem
 topológica, valida o runtime HTTPS e reconstrói a IDE. A definição única fica em
 `installer/dependencies.json`; a CI usa o mesmo manifesto.
 
+## Requisito do Python
+
+Os instaladores exigem Python 3.8 ou superior e recusam Python 2. No Windows, o
+`install_components.bat` procura o interpretador nesta ordem:
+
+1. executável informado pela variável `PYTHON_EXE`;
+2. launcher `py -3`;
+3. comando `python3`;
+4. comando `python`, desde que seja realmente Python 3.8 ou superior.
+
+O Windows 7 SP1 deve usar o Python 3.8.10, última versão da série com instalador
+compatível com esse sistema. Durante a instalação, habilite o Python Launcher e
+a inclusão no `PATH`.
+
+Quando o Python 3 estiver fora do `PATH`, informe o executável antes de instalar:
+
+```bat
+set "PYTHON_EXE=C:\Python38\python.exe"
+install_components.bat recommended
+```
+
 ## Dependências externas
 
 | Dependência | Resolução |
@@ -24,7 +45,8 @@ install_components.bat all C:\lazarus\lazbuild.exe
 ./install_components.sh recommended /usr/bin/lazbuild
 ```
 
-Variáveis opcionais: `ZEOS_ROOT`, `CEF4DELPHI_ROOT` e `GLSCENE_ROOT`.
+Variáveis opcionais: `PYTHON_EXE`, `ZEOS_ROOT`, `CEF4DELPHI_ROOT` e
+`GLSCENE_ROOT`.
 
 Instaladores completos por plataforma:
 


### PR DESCRIPTION
## O que mudou

- valida Python 3.8 ou superior antes de executar `install_suite.py`;
- impede que o `install_components.bat` selecione Python 2 silenciosamente;
- procura `PYTHON_EXE`, `py -3`, `python3` e `python`, nessa ordem;
- informa a solução específica para Windows 7 SP1;
- documenta o requisito e o uso de `PYTHON_EXE`.

## Causa

Quando `py.exe` não estava instalado, o lote usava diretamente `python`. Em máquinas nas quais esse comando apontava para Python 2, o parser falhava nas anotações de tipo do instalador.

## Validação

- conteúdo dos dois arquivos relido no branch;
- comparação com `main`: somente `install_components.bat` e `installer/README.md` foram alterados;
- branch está 2 commits à frente e 0 atrás de `main`.

A execução real no Windows 7 ainda deve ser confirmada em uma máquina com Python 2 e Python 3.8 para cobrir a seleção do interpretador.